### PR TITLE
加入对非百分比数字护甲值的兼容

### DIFF
--- a/src/Extension/WarheadTypeExt.cpp
+++ b/src/Extension/WarheadTypeExt.cpp
@@ -27,6 +27,21 @@ std::string WarheadTypeExt::GetArmorValue(std::string key, std::vector<std::pair
 			{
 				return value;
 			}
+			// 如果是不包括百分比的小数或整数，将其转化为百分比形式
+			try
+			{
+				// 尝试将字符串转为浮点数
+				float numericValue = std::stof(value);
+				
+				// 如果能成功转换，表示是一个有效的小数或整数，转化为百分比形式
+				std::ostringstream percentStream;
+				percentStream << (numericValue * 100) << "%"; // 转化为百分比形式
+				return percentStream.str(); // 返回转换后的百分比字符串
+			}
+			catch (const std::invalid_argument&)
+			{
+				// 如果转换失败，表示不是数字，继续进行后面的处理
+			}
 			// 迭代查找
 			if (value != key)
 			{


### PR DESCRIPTION
允许Kratos识别类似于以下的护甲：
[ArmorTypes]
ImmuneArmor = 0
OneArmor = 1
StrongArmor = 0.5
WeakArmor = 1.5