### PR TITLE
更改建筑Stand.Offset说明错误

### DIFF
--- a/附件包/Kratos食用说明书.ini
+++ b/附件包/Kratos食用说明书.ini
@@ -1086,7 +1086,7 @@ Info.TurretDir.Mode=NONE ;非None时，绘制单位炮塔朝向
 Info.TurretDir.Color=0,0,252 ;连线的颜色
 ; 模块：替身 —— AE生效期间，为附着对象添加一个独立单位做替身，替身会始终跟随使者行动
 Stand.Type=APOC ;替身类型，可以是虚拟单位
-Stand.Offset=0,0,0 ;替身的位置，单位的FLH，+F在建筑的右下方
+Stand.Offset=0,0,0 ;替身的位置，单位的FLH，+F在建筑的右上方，+L在建筑的左上
 Stand.StackOffset=0,0,0 ;如果出现多个相同的AE堆叠时，当前替身相比于上一个替身的位置偏移
 Stand.StackGroup=-1 ;分组堆叠，同一个组的替身堆叠在一起，后一个替身以同组的上一个替身位置偏移
 Stand.StackGroupOffset=0,0,0 ;分组堆叠，当前组相比于上一组的位置偏移


### PR DESCRIPTION
`+F`为建筑**右下**
改为：
`+F`为建筑**右上**，`+L`为建筑左上
![Stand Offset](https://github.com/user-attachments/assets/baa44ed9-ee05-43e9-9f73-e7941b8bac92)
