### PR TITLE
重新设计的Vector系统，AE化的TurretSpin、BodySpin，抛射体持有的Broadcast+AutoWeapon的特解

### DIFF
--- a/Kratos.vcxproj
+++ b/Kratos.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ShowAllFiles>true</ShowAllFiles>

--- a/Kratos.vcxproj
+++ b/Kratos.vcxproj
@@ -81,6 +81,8 @@
     <ClCompile Include="src\Ext\EffectType\Effect\StandEffect.cpp" />
     <ClCompile Include="src\Ext\EffectType\Effect\VampireEffect.cpp" />
     <ClCompile Include="src\Ext\EffectType\Effect\VectorEffect.cpp" />
+    <ClCompile Include="src\Ext\EffectType\Effect\TurretSpinEffect.cpp" />
+    <ClCompile Include="src\Ext\EffectType\Effect\BodySpinEffect.cpp" />
     <ClCompile Include="src\Ext\EffectType\State\StateEffect.cpp" />
     <ClCompile Include="src\Ext\EffectType\State\StateEffectScript.cpp" />
     <ClCompile Include="src\Ext\Helper\CastEx.cpp" />
@@ -150,6 +152,8 @@
     <ClCompile Include="src\Ext\TechnoType\Status\TargetLaser.cpp" />
     <ClCompile Include="src\Ext\TechnoType\Status\Transform.cpp" />
     <ClCompile Include="src\Ext\TechnoType\Status\Vampire.cpp" />
+    <ClCompile Include="src\Ext\TechnoType\Status\BodySpin.cpp" />
+    <ClCompile Include="src\Ext\TechnoType\Status\TurretSpin.cpp" />
     <ClCompile Include="src\Ext\TechnoType\Status\Vector.cpp" />
     <ClCompile Include="src\Ext\TechnoType\Spawn.cpp" />
     <ClCompile Include="src\Ext\TechnoType\SupportSpawns.cpp" />
@@ -306,6 +310,10 @@
     <ClInclude Include="src\Ext\EffectType\Effect\VampireEffect.h" />
     <ClInclude Include="src\Ext\EffectType\Effect\VectorData.h" />
     <ClInclude Include="src\Ext\EffectType\Effect\VectorEffect.h" />
+    <ClInclude Include="src\Ext\EffectType\Effect\TurretSpinData.h" />
+    <ClInclude Include="src\Ext\EffectType\Effect\TurretSpinEffect.h" />
+    <ClInclude Include="src\Ext\EffectType\Effect\BodySpinData.h" />
+    <ClInclude Include="src\Ext\EffectType\Effect\BodySpinEffect.h" />
     <ClInclude Include="src\Ext\EffectType\State\StateEffect.h" />
     <ClInclude Include="src\Ext\EffectType\State\StateEffectScript.h" />
     <ClInclude Include="src\Ext\Helper\CastEx.h" />

--- a/Vector标签说明书.txt
+++ b/Vector标签说明书.txt
@@ -42,7 +42,8 @@ Vector.OriginFLH=F,L,H
 
 Vector.OriginNoUpdate=yes/no
   yes = 原点锁定在获得 AE 瞬间的坐标，不跟随移动。
-  Origin=Launcher 时默认 yes，其余默认 no。
+  所有 Origin 默认 no（每帧动态刷新）。
+  显式设为 yes 才锁定。
 
 Vector.Force=yes/no
   yes = 彻底跳过引擎轨迹计算，Vector 直接 SetLocation 控制位置。
@@ -81,7 +82,7 @@ Vector.CircleMinSpeed=N
   线速度下限。0 = 不限（支持负值限幅）。
   默认 0。
 
-Vector.CircleAnglePerFrame=N
+Vector.CircleAnglePerStep=N
   角速度（°/step），正值逆时针、负值顺时针。
   未设时由半径和线速度自动推算。
   默认 0。
@@ -122,7 +123,7 @@ Vector.CircleEndOnMinRadius=yes/no
 [CircleAroundTarget]
 Duration=400
 Vector.CircleRadius=512
-Vector.CircleAnglePerFrame=5
+Vector.CircleAnglePerStep=5
 Vector.Origin=Target
 
 --- 示例：外扩螺旋 + 上限停止 ---
@@ -130,7 +131,7 @@ Vector.Origin=Target
 Duration=400
 Vector.CircleRadius=64
 Vector.CircleRadiusGrow=2
-Vector.CircleAnglePerFrame=5
+Vector.CircleAnglePerStep=5
 Vector.CircleMaxRadius=512
 Vector.CircleEndOnMaxRadius=yes
 Vector.Origin=Target
@@ -140,7 +141,7 @@ Vector.Origin=Target
 Duration=400
 Vector.CircleRadius=512
 Vector.CircleRadiusGrow=-2
-Vector.CircleAnglePerFrame=5
+Vector.CircleAnglePerStep=5
 Vector.CircleMinRadius=32
 Vector.CircleEndOnMinRadius=yes
 Vector.Origin=Target
@@ -160,7 +161,7 @@ Vector.GrowRate=F,L,H
   只计算运动帧（受 TimeStep 约束）。
   默认 0,0,0。
 
-Vector.AnglePerFrame=N
+Vector.AnglePerStep=N
   每帧自增角度（°/step）。叠加到当前 FLH 朝向上，使位移向量持续旋转。
   0 = 跟随物体当前朝向；非 0 = 画圆/螺旋。
   默认 0。
@@ -174,13 +175,13 @@ Vector.MoveTo=0,100,0
 [SelfCircle]
 Duration=400
 Vector.MoveTo=0,100,0
-Vector.AnglePerFrame=5
+Vector.AnglePerStep=5
 
 --- 示例：绕 Target 画圆（配合 Origin=Target）---
 [CircleTarget]
 Duration=400
 Vector.MoveTo=100,0,0
-Vector.AnglePerFrame=5
+Vector.AnglePerStep=5
 Vector.Origin=Target
 
 --- 示例：呼吸效果（位移逐渐缩小）---
@@ -227,6 +228,22 @@ Vector.MinSpeed=N
   最小速度钳位。-1 = 不限。允许设 0 为静止或负值为反向。
   默认 -1。
 
+Vector.ArcHeight=N
+  抛物线弧高（lepton）。仅 ReachTarget=yes 时生效。
+  正=先升后降（上凸），负=先降后升（下凹），0=直线（默认）。
+  弧顶相对起终点连线的最大垂直偏移。
+  默认 0。
+
+Vector.AllowFallingDestroy=yes/no
+  yes = 向量效果结束时，若单位在空中且超出指定高度，直接摔死。
+  no  = 结束时空单位从当前高度自由坠落。
+  默认 no。
+
+Vector.FallingDestroyHeight=N
+  致死高度（lepton）。AllowFallingDestroy=yes 时有效。
+  超出此高度则摔死，否则正常坠落。
+  默认 2 * LevelHeight（约 2 层高度）。
+
 --- 示例：恒速直线飞行 ---
 [FlyStraight]
 Duration=300
@@ -251,6 +268,15 @@ Vector.TargetFLH=3000,0,3000
 Vector.Origin=Launcher
 Vector.ReachTarget=yes
 
+--- 示例：抛物线飞行 ---
+[ParabolaFly]
+Duration=60
+Vector.TargetFLH=0,0,10
+Vector.Origin=Target
+Vector.ReachTarget=yes
+Vector.ArcHeight=2000
+Vector.Force=yes
+
 ============================================================
 参考系（Origin 详细说明）
 ============================================================
@@ -264,19 +290,19 @@ FLH
 Launcher
   F 轴 = 发射者 → 抛射体连线
   L 轴 = F 轴左侧 90°
-  原点 = 发射者坐标（每帧刷新，除非 NoUpdate）
-  NoUpdate 默认 yes（锁定发射瞬间位置）
+  原点 = 发射者坐标（每帧刷新，除非 OriginNoUpdate=yes）
+  适用：以发射者为基点的位移
 
 Target
   F 轴 = 目标 → 抛射体连线
   L 轴 = F 轴左侧 90°
-  原点 = 目标坐标（优先 pBullet->Target，次选 Owner->Target）
-  每帧刷新，除非 NoUpdate
+  原点 = 目标坐标（优先 pBullet->Target 实时坐标，次选 Owner->Target）
+  每帧刷新，除非 OriginNoUpdate=yes
 
 Source
   F 轴 = AE 来源单位 → 抛射体连线
   L 轴 = F 轴左侧 90°
-  原点 = AE 来源单位坐标（每帧刷新，除非 NoUpdate）
+  原点 = AE 来源单位坐标（每帧刷新，除非 OriginNoUpdate=yes）
 
 所有模式下 F/L 轴均只使用 XY 分量计算，Z 不纳入以避免倾斜坐标系。
 
@@ -327,5 +353,5 @@ Next=CIRCLE
 [CIRCLE]              ; 第二段：绕目标画圆
 Duration=400
 Vector.CircleRadius=512
-Vector.CircleAnglePerFrame=5
+Vector.CircleAnglePerStep=5
 Vector.Origin=Target

--- a/Vector标签说明书.txt
+++ b/Vector标签说明书.txt
@@ -1,636 +1,331 @@
-﻿ ============================================================
- Vector 效果器 INI 标签说明书
  ============================================================
- Vector 是一种纯位移效果器，在 Duration 期间直接修改附着对象的坐标。
- 适用于 Aircraft、Jumpjet Vehicle、Projectile 等所有非建筑类型。
- BuildingTypes 永久免疫，不论 INI 如何设置。
-
- 所有标签写在 [AttachEffectSection] 下，前缀为 Vector.
- 示例：
-   [MyVectorAE]
-   Duration=300
-   Vector.MoveTo=0,0,16
-   Vector.AnglePerFrame=5
-
- 架构：
-   VectorEffect 为纯数据容器，存储配置和运行时状态。
-   运动计算由 TechnoStatus（Techno）和 BulletStatus（Bullet）统一执行。
-   多个 Vector 的位移向量叠加后，一次性执行碰撞检测和 SetLocation。
-   与 BlackHole 架构对齐：数据在 EffectScript，计算在 Status。
- ============================================================
-
- ------------------------------------------------------------
- 基础运动参数
- ------------------------------------------------------------
-
- Vector.TargetFLH=X,Y,Z
-   最终目标坐标。对象在持续时间内朝此方向飞行。
-   坐标含义由 Vector.Origin 决定。
-   默认 0,0,0（不启用目标飞行，仅用 MoveTo 偏移）。
-Vector.TargetFLH=0,0,0
-
- Vector.TargetRandF=Min,Max
-   随机前向偏移范围（lepton）。效果获得瞬间随机生成一次，此后不再刷新。
-   最终随机目标前向分量 = TargetFLH.F + Random(Min, Max)。
-   默认 0,0（不启用随机）。
-Vector.TargetRandF=0,0
-
- Vector.TargetRandL=Min,Max
-   随机左向偏移范围（lepton）。
-   最终随机目标左向分量 = TargetFLH.L + Random(Min, Max)。
-   默认 0,0。
-Vector.TargetRandL=0,0
-
- Vector.TargetRandH=Min,Max
-   随机高度偏移范围（lepton）。
-   最终随机目标高度分量 = TargetFLH.H + Random(Min, Max)。
-   默认 0,0。
-Vector.TargetRandH=0,0
-
- Vector.ReachTarget=yes/no
-   设为 yes 时，系统根据剩余时间和距离自动计算速度，
-   保证 Duration 结束时恰好到达 TargetFLH。
-   默认 no（恒定速度飞行，到不到不管）。
-Vector.ReachTarget=no
-
- Vector.MoveTo=X,Y,Z
-   坐标偏移量。
-   线性模式（无 Radius）：每帧位移向量，对象沿此方向移动。
-   圆周模式（有 Radius）：圆心相对原点的偏移量。
-   多个 Vector 的 MoveTo 独立计算后位移叠加。
-   默认 0,0,0。
-Vector.MoveTo=0,0,0
-
- Vector.Radius=lepton
-   圆形轨迹半径。设为非零值时进入圆周模式。
-   圆周模式下：圆心 = Origin + TargetFLH + MoveTo，物体绕圆心旋转。
-   与 Speed/StartSpeed 配合决定角速度。
-   默认 0（线性模式）。
-Vector.Radius=0
-
- Vector.Force=yes/no
-   强制位移模式。设为 yes 时，完全忽略抛射体的原版飞行轨迹计算，
-   只使用 Vector 的强制位移。适用于需要完全控制抛射体路径的场景。
-   对 Techno/Aircraft 无影响（它们本身没有原版弹道）。
-   默认 no。
-Vector.Force=no
-
- Vector.Freeze=yes/no
-   冻结模式。设为 yes 时，物体停留在当前坐标不移动，但 Duration 仍在计时。
-   自旋（SpinRate）仍然生效。
-   用于先冻结再释放，或配合其他效果器使用。
-   默认 no。
-Vector.Freeze=no
-
- ------------------------------------------------------------
- 速度控制
- ------------------------------------------------------------
-
- Vector.StartSpeed=速度值
-   初始速度。
-   线性模式：线速度（lepton/step）。
-   圆周模式：角速度（°/step），若未设置则由 AnglePerFrame 推算。
-   默认 0（自动读取 Techno 的 Speed）。
-Vector.StartSpeed=0
-
- Vector.EndSpeed=速度值
-   终止速度。配合 Acceleration 使用。
-   线性模式：终止线速度。
-   圆周模式：终止角速度。
-   设为 -1 时不限制。
-   默认 -1。
-Vector.EndSpeed=-1
-
- Vector.Acceleration=变化量/step
-   每 step 速度变化量。正=加速，负=减速。
-   线性模式：线加速度。
-   圆周模式：角加速度。
-   受 FrameStep 约束，只在运动帧执行。
-   默认 0（恒速）。
-Vector.Acceleration=0
-
- Vector.FrameStep=N
-   运动颗粒度。每 N 帧执行一次位移/旋转/状态更新。
-   例如 FrameStep=3 表示每 3 帧移动一次，实际速度 = StartSpeed / 3。
-   同时约束以下参数的执行频率：
-     Acceleration、GrowRate、SpinAcceleration、TurretSpinAcceleration、
-     SpeedOscillation、SpinOscillation、TurretSpinOscillation、
-     GrowOscillation、WaveAmpOscillation、WaveFreqOscillation、
-     WaveFreqAcceleration
-   默认 1（每帧执行）。
-Vector.FrameStep=1
-
- Vector.SpeedOscillation=度数
-   速度振荡幅度。叠加在基础速度上的正弦波振幅。
-   线性模式：实际线速度 = _currentSpeed + SpeedOscillation * sin(...)
-   圆周模式：实际角速度 = _currentSpeed / Radius + SpeedOscillation / Radius * sin(...)
-   受 FrameStep 约束，只在运动帧计算。
-   默认 0（不振荡）。
-Vector.SpeedOscillation=0
-
- Vector.SpeedOscFreq=度数/step
-   速度振荡频率。360 = 一周期。
-   时间单位为 step（受 FrameStep 约束的运动帧）。
-   默认 0。
-Vector.SpeedOscFreq=0
-
- Vector.SpeedOscPhase=度数
-   速度振荡初始相位。
-   默认 0。
-Vector.SpeedOscPhase=0
-
- Vector.GrowRate=X,Y,Z
-   线性模式：MoveTo 每 step 增长量（呼吸效果）。
-   圆周模式：X=半径每 step 增长量（螺旋），Z=圆心垂直偏移增长量。
-   受 FrameStep 约束，只在运动帧增长。
-   默认 0,0,0。
-Vector.GrowRate=0,0,0
-
- Vector.GrowOscillationX=Y,Z=振幅, GrowOscFreqX=Y,Z=频率, GrowOscPhaseX=Y,Z=相位
-   GrowRate 的正弦振荡分量。三轴独立控制。
-   实际增长率 = GrowRate + GrowOscillation * sin(GrowOscFreq * step + GrowOscPhase)
-   用于实现呼吸效果的周期性膨胀/收缩。
-   受 FrameStep 约束。
-   默认全部 0（不振荡）。
-Vector.GrowOscillationX=0
-Vector.GrowOscillationY=0
-Vector.GrowOscillationZ=0
-Vector.GrowOscFreqX=0
-Vector.GrowOscFreqY=0
-Vector.GrowOscFreqZ=0
-Vector.GrowOscPhaseX=0
-Vector.GrowOscPhaseY=0
-Vector.GrowOscPhaseZ=0
-
- Vector.WaveAmplitude=X,Y,Z
-   振荡振幅。三轴分别控制。
-   配合 WaveFrequency 使用，每轴独立正弦波。
-   默认 0,0,0（不振荡）。
-Vector.WaveAmplitude=0,0,0
-
- Vector.WaveFrequency=X,Y,Z
-   振荡频率（度/step）。三轴分别控制。
-   360 = 一周期。例如 5 → 72 step 一周期。
-   三轴频率互质时不闭合（李萨如图形）。
-   默认 0,0,0。
-Vector.WaveFrequency=0,0,0
-
- Vector.WavePhase=X,Y,Z
-   振荡初始相位（度）。三轴分别控制。
-   用于错开多轴振荡（如 0,90,0 → X/Y 差90度相位）。
-   默认 0,0,0。
-Vector.WavePhase=0,0,0
-
- Vector.WaveFreqAcceleration=X,Y,Z
-   波频率加速度（度/step²）。每 step 叠加到当前波频率上。
-   三轴分别控制。正值→频率加快（波形变密），负值→频率减慢（波形变疏）。
-   受 FrameStep 约束，只在运动帧执行。
-   受 WaveFreqEndSpeed 限制。
-   默认 0,0,0（频率恒定）。
-Vector.WaveFreqAcceleration=0,0,0
-
- Vector.WaveFreqEndSpeed=X,Y,Z
-   波频率终止值（度/step）。配合 WaveFreqAcceleration 使用。
-   频率在此区间内被钳位（min/max）。
-   设为 0 时不限制。
-   默认 0,0,0（不限制）。
-Vector.WaveFreqEndSpeed=0,0,0
-
- Vector.WaveAmpOscillation=百分比
-   振幅 LFO（低频振荡器）幅度。以百分比调制当前振幅。
-   公式: 最终振幅 = 基础振幅 × (1 + WaveAmpOscillation/100 × sin(...))
-   例如 50 → 振幅在 ±50% 间脉动。
-   受 FrameStep 约束，只在运动帧计算。
-   默认 0（不振荡）。
-Vector.WaveAmpOscillation=0
-
- Vector.WaveAmpOscFreq=度数/step
-   振幅 LFO 频率。360 = 一周期。
-   时间单位为 step（受 FrameStep 约束的运动帧），不是原始帧。
-   默认 0。
-Vector.WaveAmpOscFreq=0
-
- Vector.WaveAmpOscPhase=度数
-   振幅 LFO 初始相位。
-   默认 0。
-Vector.WaveAmpOscPhase=0
-
- Vector.WaveFreqOscillation=度数
-   频率 LFO 幅度。以绝对值叠加到当前波频率上。
-   公式: 最终频率 = 基础频率 + WaveFreqOscillation × sin(...)
-   例如 10 → 频率在 ±10度/step 间抖动。
-   受 FrameStep 约束，只在运动帧计算。
-   默认 0（不振荡）。
-Vector.WaveFreqOscillation=0
-
- Vector.WaveFreqOscFreq=度数/step
-   频率 LFO 频率。360 = 一周期。
-   时间单位为 step（受 FrameStep 约束的运动帧），不是原始帧。
-   默认 0。
-Vector.WaveFreqOscFreq=0
-
- Vector.WaveFreqOscPhase=度数
-   频率 LFO 初始相位。
-   默认 0。
-Vector.WaveFreqOscPhase=0
-
- ------------------------------------------------------------
- 旋转（画圆/螺旋）
- ------------------------------------------------------------
-
- Vector.AnglePerFrame=度数
-   每 step 旋转角度。正=顺时针，负=逆时针。
-   圆周模式：若未设 StartSpeed，则用此值作为角速度。
-   若同时设了 StartSpeed 和 AnglePerFrame，以 StartSpeed 为准。
-   默认 0。
-Vector.AnglePerFrame=0
-
- Vector.RotateAxis=X/Y/Z
-   旋转轴预设。有 RotateDirection 时被覆盖。
-   Z = 水平面画圆（最常用）
-   X = 前后翻转画圆
-   Y = 左右翻转画圆
-   默认 Z。
-Vector.RotateAxis=Z
-
- Vector.RotateDirection=X,Y,Z
-   自定义旋转轴方向（世界坐标系）。
-   优先级高于 RotateAxis。
-   示例：1,1,0 → 绕45度斜轴旋转，画出椭圆轨迹。
-   默认 0,0,0（使用 RotateAxis）。
-Vector.RotateDirection=0,0,0
-
- ------------------------------------------------------------
- 自旋（模型旋转）
- ------------------------------------------------------------
-
- Vector.SpinRate=度数/step
-   Body 自旋初始角速度。正=顺时针，负=逆时针。
-   受 FrameStep 约束，只在运动帧更新。
-   多个 Vector 的 SpinRate 叠加（Rodrigues 旋转）。
-   对 Techno（PrimaryFacing）和 Bullet（Direction）均有效。
-   默认 0（不自旋）。
-Vector.SpinRate=0
-
- Vector.SpinEndSpeed=度数/step
-   Body 自旋终止角速度。配合 SpinAcceleration 使用。
-   设为 -1 时不限制。默认 -1。
-Vector.SpinEndSpeed=-1
-
- Vector.SpinAcceleration=度数/step²
-   Body 自旋角加速度。受 FrameStep 约束。默认 0。
-Vector.SpinAcceleration=0
-
- Vector.SpinOscillation=度数
-   Body 自旋振荡幅度。叠加在基础角速度上的正弦波。
-   实际角速度 = SpinRate + SpinAcceleration * step + SpinOscillation * sin(...)
-   受 FrameStep 约束。默认 0。
-Vector.SpinOscillation=0
-
- Vector.SpinOscFreq=度数/step
-   Body 自旋振荡频率。默认 0。
-Vector.SpinOscFreq=0
-
- Vector.SpinOscPhase=度数
-   Body 自旋振荡初始相位。默认 0。
-Vector.SpinOscPhase=0
-
- Vector.SpinAxis=X/Y/Z
-   自旋轴预设（物体局部坐标系）。有 SpinDirection 时被覆盖。
-   Z = 绕垂直轴水平自转（最常见）
-   X = 翻滚（Roll）
-   Y = 俯仰（Pitch）
-   默认 Z。
-Vector.SpinAxis=Z
-
- Vector.SpinDirection=X,Y,Z
-   自定义自旋轴方向（局部坐标系）。
-   优先级高于 SpinAxis。
-   默认 0,0,0（使用 SpinAxis）。
-Vector.SpinDirection=0,0,0
-
- ------------------------------------------------------------
- 炮塔自旋
- ------------------------------------------------------------
-
- Vector.TurretSpinRate=度数/step
-   炮塔自旋初始角速度。与 SpinRate 用法一致。
-   多个 Vector 的 TurretSpinRate 叠加（Rodrigues 旋转）。
-   默认 0。
-Vector.TurretSpinRate=0
-
- Vector.TurretSpinEndSpeed=度数/step
-   炮塔自旋终止角速度。默认 -1（不限制）。
-Vector.TurretSpinEndSpeed=-1
-
- Vector.TurretSpinAcceleration=度数/step²
-   炮塔自旋角加速度。受 FrameStep 约束。默认 0。
-Vector.TurretSpinAcceleration=0
-
- Vector.TurretSpinOscillation=度数
-   炮塔自旋振荡幅度。受 FrameStep 约束。默认 0。
-Vector.TurretSpinOscillation=0
-
- Vector.TurretSpinOscFreq=度数/step
-   炮塔自旋振荡频率。默认 0。
-Vector.TurretSpinOscFreq=0
-
- Vector.TurretSpinOscPhase=度数
-   炮塔自旋振荡初始相位。默认 0。
-Vector.TurretSpinOscPhase=0
-
- Vector.TurretSpinAxis=X/Y/Z
-   炮塔自旋轴预设。默认 Z。
-Vector.TurretSpinAxis=Z
-
- Vector.TurretSpinDirection=X,Y,Z
-   自定义炮塔自旋轴方向。优先级高于 TurretSpinAxis。
-   默认 0,0,0。
-Vector.TurretSpinDirection=0,0,0
-
- Vector.FreeTurret=yes/no
-   炮塔自由模式。设为 yes 时，炮塔完全独立旋转（不受 Body 自旋影响）。
-   默认 no（炮塔跟随 Body 的旋转）。
-Vector.FreeTurret=no
-
- ------------------------------------------------------------
- 朝向控制
- ------------------------------------------------------------
-
- Vector.Facing=Destination/Target/Initial
-   基础朝向模式。SpinRate 在此基础上叠加自旋。
-   多个 Vector 时，取第一个活跃 Vector 的 Facing。
-   Destination = 朝向 MoveTo/TargetFLH 方向
-   Target = 朝向原始瞄准目标
-   Initial = 保持吃到效果时的朝向
-   默认 Destination。
-Vector.Facing=Destination
-
- ------------------------------------------------------------
- 参考系
- ------------------------------------------------------------
-
- Vector.Origin=World/Target/Launcher/Self/Realtime/Source/FLH
-    TargetFLH 和 MoveTo 的计算参考系。
-    每个 Vector 独立使用自己的 Origin 计算位移向量。
-    World = 世界坐标系，直接使用坐标值
-    Target = 以抛射体/单位的原始目标为原点
-    Launcher = 以发射者为原点（每帧动态读取发射者位置）
-    Self = 以吃到效果瞬间的自身位置为原点（最常用）
-    Realtime = 每帧以当前自身位置为原点（用于绕自身画圆）
-    Source = 以AE来源单位为原点（施加效果的单位，每帧动态读取）
-    FLH = 以获得AE时单位面朝方向为F计算偏移后的世界坐标作为固定原点
-          原点 = 单位坐标 + RotateByFacing(OriginFLH, 单位朝向)，此后不变
-    默认 Self。
-
-  Vector.OriginFLH=F,L,H
-    Origin=FLH 时生效。以获得AE时单位所在坐标为原点，单位面朝方向为F（前方），
-    L为左方，H为高度，计算偏移后的世界坐标作为固定原点。
-    示例：OriginFLH=0,512,0 → 原点在单位正前方512处
-    默认 0,0,0。
-
- Vector.OriginNoUpdate=yes/no
-   设为 yes 时，Target/Launcher/Source 只取效果获得瞬间的坐标，
-   此后不再追踪移动。用于锚定到某个时刻的位置。
-   默认 no（每帧动态追踪）。
-Vector.OriginNoUpdate=no
-   默认 Self。
-Vector.Origin=Self
-
- ------------------------------------------------------------
- 筛选与权重
- ------------------------------------------------------------
-
- Vector.Weight=数值
-   向量权重。用于与 BlackHole 的交互判断。
-   Vector 之间不争夺，直接叠加。
-   默认 -1。
-Vector.Weight=-1
-
- Vector.AffectAircraft=yes/no
-   是否影响 Aircraft。默认 yes。
-Vector.AffectAircraft=yes
-
- Vector.AffectJumpjet=yes/no
-   是否影响 Jumpjet Vehicle。默认 yes。
-Vector.AffectJumpjet=yes
-
- Vector.AffectBullet=yes/no
-   是否影响 Projectile。默认 yes。
-Vector.AffectBullet=yes
-
- ------------------------------------------------------------
- 继承自 EffectData 的通用参数（可选）
- ------------------------------------------------------------
-
- Vector.Enable=yes/no
-   手动启用/禁用。默认自动判断（有 MoveTo/TargetFLH/AnglePerFrame/SpinRate/WaveAmplitude 时自动启用）。
-
- Vector.AffectTypes=类型1,类型2,...
-   白名单。只有列表中的 TechnoType/BulletType 才受此效果影响。
-   默认空（影响所有）。
-
- Vector.NotAffectTypes=类型1,类型2,...
-   黑名单。列表中的类型不受此效果影响。
-
- Vector.AffectTechno=yes/no
-   是否影响 Techno（建筑+步兵+载具+飞机）。默认 yes。
-
- Vector.AffectSelf=yes/no
-   是否影响施加者自身。默认 no。
-
- Vector.AffectInAir=yes/no
-   是否影响空中单位。默认 yes。
-
- Vector.AffectsOwner=yes/no
-   是否影响所属方。默认 yes。
-
- Vector.AffectsAllies=yes/no
-   是否影响盟友。默认 yes。
-
- Vector.AffectsEnemies=yes/no
-   是否影响敌方。默认 yes。
-
- Vector.AffectsCivilian=yes/no
-   是否影响平民。默认 yes。
-
- Vector.AuxBuildings=建筑1,建筑2,...
-   前置建筑。所属方必须拥有列表中至少一个建筑，效果才生效。
-
- Vector.NegBuildings=建筑1,建筑2,...
-   排除建筑。所属方拥有列表中任意建筑时，效果不生效。
-
- Vector.Powered=yes/no
-   是否需要电力。建筑断电时效果暂停。默认 no。
-
- Vector.CheckHealthPrecent=yes/no
-   是否检查血量比例。默认 no。
-
- Vector.ActiveWhenHealthPercent=比例
-   血量低于此比例时激活效果（0~1）。默认 1。
-
- Vector.DeactiveWhenHealthPercent=比例
-   血量高于此比例时停用效果（0~1）。默认 0。
-
- Vector.TriggeredTimes=次数
-   最大触发次数。达到后效果结束。默认 -1（无限）。
-
- Vector.AffectWho=Master/Stand/All
-   影响对象。Master=使者, Stand=替身, All=都影响。默认 Master。
-
- Vector.DeactiveWhenCivilian=yes/no
-   平民是否不生效。默认 no。
-
- ============================================================
- 叠加规则
- ============================================================
- 多个带 Vector 效果的 AE 可以同时附加到一个对象上。
-
- 每个 VectorEffect 独立计算自己的运动向量：
-   displacement_i = nextPos_i - currentPos
-   finalPos = currentPos + Σ displacement_i
-
- 每个 Vector 使用自己的 Origin/TargetFLH/Speed/Radius 等参数独立计算。
- 多个 Vector 的位移向量叠加后，一次性执行碰撞检测和 SetLocation。
-
- Facing: 取第一个活跃 Vector 的 Facing（first-only + 级联）。
- Spin/TurretSpin: 所有 Vector 叠加（Rodrigues 旋转），FreeTurret 控制炮塔跟随。
- Duration: per-Vector，结束后其位移贡献移除。
- 所有变化系数受 FrameStep 统一约束。
-
- 结束规则：所有 VectorEffect 结束时触发落地逻辑（FallingExceptAircraft）。
-
- BuildingTypes 永久免疫，不论 AffectBuilding 设置。
-
- ============================================================
- 与 BlackHole 的交互
- ============================================================
- BlackHole 捕获时，Vector 停止执行但不移除。
- BlackHole 释放后，Vector 自动恢复执行。
- Vector 之间不争夺，直接叠加。
-
- ============================================================
- 示例
- ============================================================
-
- --- 匀速直线 ---
- [FlyStraightAE]
- Duration=300
- Vector.MoveTo=0,16,0          方向偏移
- Vector.StartSpeed=16          线速度 16 lepton/step
- Vector.Origin=Self
-
- --- 匀速画圆（半径512，线速度50）---
- [CircleAE]
- Duration=720
- Vector.Radius=512
- Vector.StartSpeed=50          沿圆周线速度 50
- Vector.Origin=Self
-
- --- 匀速画圆（指定角速度）---
- [CircleByAngleAE]
- Duration=720
- Vector.Radius=512
- Vector.AnglePerFrame=5        5°/step（未设 StartSpeed 时使用）
- Vector.Origin=Self
-
- --- 渐开螺旋（半径递增）---
- [InvoluteSpiralAE]
- Duration=600
- Vector.Radius=64              初始半径
- Vector.GrowRate=4,0,0         X=半径每step+4
- Vector.StartSpeed=50          沿圆周线速度恒定 50
- Vector.Origin=Self
-
- --- 收敛螺旋（半径递减）---
- [ConvergeSpiralAE]
- Duration=600
- Vector.Radius=512
- Vector.GrowRate=-4,0,0        X=半径每step-4
- Vector.StartSpeed=50
- Vector.Origin=Self
-
- --- 螺旋上升 ---
- [SpiralUpAE]
- Duration=600
- Vector.Radius=512
- Vector.GrowRate=0,0,2         Z=圆心每step上升 2
- Vector.StartSpeed=50
- Vector.Origin=Self
-
- --- 加速旋转 ---
- [AccelCircleAE]
- Duration=600
- Vector.Radius=512
- Vector.StartSpeed=2           初始角速度 2°/step
- Vector.EndSpeed=10            终止角速度 10°/step
- Vector.Acceleration=0.5       每step +0.5°
- Vector.Origin=Self
-
- --- 慢速画圆（颗粒度控制）---
- [SlowCircleAE]
- Duration=720
- Vector.Radius=512
- Vector.StartSpeed=15          角速度 15°/step
- Vector.FrameStep=3            每3帧转一次 → 实际 5°/step
- Vector.Origin=Self
-
- --- 冻结 + 自旋 ---
- [FreezeSpinAE]
- Duration=300
- Vector.Freeze=yes
- Vector.SpinRate=15
- Vector.Origin=Self
-
- --- 叠加组合：圆 + 上升 ---
- [AE_Circle]
- Duration=600
- Vector.Radius=512
- Vector.StartSpeed=50
- Vector.Origin=Self
-
- [AE_Up]
- Duration=600
- Vector.MoveTo=0,0,2           线性模式：每step上升 2
-
- --- 李萨如图形（三轴正弦波叠加）---
- [LissajousAE]
- Duration=1000
- Vector.WaveAmplitude=256,256,0
- Vector.WaveFrequency=5,7,0
- Vector.StartSpeed=0
-
- --- 3D锥形螺旋（自定义旋转轴）---
- [ConeSpiralAE]
- Duration=600
- Vector.Radius=64
- Vector.GrowRate=2,2,1
- Vector.StartSpeed=50
- Vector.RotateDirection=1,1,1
- Vector.Origin=Self
-
- --- 振幅脉动正弦波 ---
- [PulseWaveAE]
- Duration=600
- Vector.WaveAmplitude=0,256,0
- Vector.WaveFrequency=6,0,0
- Vector.WaveAmpOscillation=80        振幅在 ±80% 间脉动
- Vector.WaveAmpOscFreq=30            脉动周期 = 360/30 = 12 step
- Vector.Origin=Self
-
-  --- 频率抖动正弦波 ---
-  [FreqJitterAE]
-  Duration=600
-  Vector.WaveAmplitude=0,256,0
-  Vector.WaveFrequency=6,0,0
-  Vector.WaveFreqOscillation=3        频率在 ±3度/step 间抖动
-  Vector.WaveFreqOscFreq=20           抖动周期 = 360/20 = 18 step
-  Vector.Origin=Self
-
-  --- FLH原点偏移（在单位前方固定位置生成原点）---
-  [FLHOriginAE]
+Vector 效果器 INI 标签说明书
+版本: 2026-06-15
+============================================================
+
+Vector 是纯位移效果器，Duration 期间强制修改附着对象坐标。
+适用于 Aircraft、Jumpjet Vehicle、Projectile、Infantry 等。
+BuildingTypes 永久免疫。
+
+所有标签写在 [AttachEffectSection] 下，前缀为 Vector.
+示例：
+  [MyVectorAE]
   Duration=300
-  Vector.Origin=FLH                   以面朝方向计算偏移原点
-  Vector.OriginFLH=0,512,0            原点在单位正前方512处
-  Vector.TargetFLH=0,0,256            目标在原点上方256
-  Vector.StartSpeed=50
+  Vector.Force=yes
+  Vector.MoveTo=0,100,0
+
+============================================================
+模式优先级
+============================================================
+Freeze > Circle > MoveTo > TargetFLH (ReachTarget → Speed)
+
+每个 AE 同时只能有一种模式生效，按优先级匹配。
+
+============================================================
+通用标签
+============================================================
+
+Vector.TimeStep=N
+  运动颗粒度。每 N 帧执行一次位移。
+  默认 1（每帧执行）。
+
+Vector.Origin=FLH / Launcher / Target / Source
+  FLH      = 抛射体自身朝向为 F 轴（默认）
+  Launcher = 发射者为原点，F 轴 = 发射者 → 抛射体
+  Target   = 目标为原点，F 轴 = 目标 → 抛射体
+  Source   = AE 来源单位为原点，F 轴 = 来源 → 抛射体
+  默认 FLH。
+
+Vector.OriginFLH=F,L,H
+  Origin=FLH 时的原点偏移（FLH 坐标系）。
+  默认 0,0,0。
+
+Vector.OriginNoUpdate=yes/no
+  yes = 原点锁定在获得 AE 瞬间的坐标，不跟随移动。
+  Origin=Launcher 时默认 yes，其余默认 no。
+
+Vector.Force=yes/no
+  yes = 彻底跳过引擎轨迹计算，Vector 直接 SetLocation 控制位置。
+  所有模式下均适用。MoveTo 和 Circle 模式自动等价 Force=yes。
+  默认 no。
+
+Vector.Freeze=yes/no
+  yes = 冻结在获得 AE 时的位置，Duration 继续计时。
+  Freeze 为最高优先级，启用时忽略所有位移配置。
+  默认 no。
+
+============================================================
+Circle 模式（圆周）
+============================================================
+优先级最高（除 Freeze 外）。圆心 = Origin，半径/线速/角速三选二。
+半径每帧动态计算，支持长缩和边界控制。
+
+Vector.CircleRadius=N
+  初始圆半径（lepton）。-1 或 0 = 自动取抛射体到原点的当前 XY 距离。
+  默认 -1。
+
+Vector.CircleSpeed=N
+  线速度（lepton/step），沿圆周切向。正值=逆时针，负值=顺时针。
+  未设时由半径和角速度自动推算。
+  默认 0。
+
+Vector.CircleSpeedAcceleration=N
+  线速度每步加速度（lepton/step²）。正=加速，负=减速。
+  默认 0。
+
+Vector.CircleMaxSpeed=N
+  线速度上限。0 = 不限（支持负值限幅）。
+  默认 0。
+
+Vector.CircleMinSpeed=N
+  线速度下限。0 = 不限（支持负值限幅）。
+  默认 0。
+
+Vector.CircleAnglePerFrame=N
+  角速度（°/step），正值逆时针、负值顺时针。
+  未设时由半径和线速度自动推算。
+  默认 0。
+
+Vector.CircleAngleAcceleration=N
+  角速度每步加速度（°/step²）。正=加速，负=减速。
+  默认 0。
+
+Vector.CircleMaxAngle=N
+  角速度上限。0 = 不限（支持负值限幅）。
+  默认 0。
+
+Vector.CircleMinAngle=N
+  角速度下限。0 = 不限（支持负值限幅）。
+  默认 0。
+
+Vector.CircleRadiusGrow=N
+  半径每步增长率（lepton/step）。正值外扩（螺旋），负值内缩。
+  默认 0（半径恒定）。
+
+Vector.CircleMaxRadius=N
+  半径上限（lepton）。0 = 不限。
+  默认 0。
+
+Vector.CircleMinRadius=N
+  半径下限（lepton）。0 = 不限。
+  默认 0。
+
+Vector.CircleEndOnMaxRadius=yes/no
+  yes = 半径达到上限时强制结束 AE。
+  默认 no。
+
+Vector.CircleEndOnMinRadius=yes/no
+  yes = 半径达到下限时强制结束 AE。
+  默认 no。
+
+--- 示例：绕 Target 匀速圆周 ---
+[CircleAroundTarget]
+Duration=400
+Vector.CircleRadius=512
+Vector.CircleAnglePerFrame=5
+Vector.Origin=Target
+
+--- 示例：外扩螺旋 + 上限停止 ---
+[SpiralOut]
+Duration=400
+Vector.CircleRadius=64
+Vector.CircleRadiusGrow=2
+Vector.CircleAnglePerFrame=5
+Vector.CircleMaxRadius=512
+Vector.CircleEndOnMaxRadius=yes
+Vector.Origin=Target
+
+--- 示例：内缩螺旋 + 下限消失 ---
+[SpiralIn]
+Duration=400
+Vector.CircleRadius=512
+Vector.CircleRadiusGrow=-2
+Vector.CircleAnglePerFrame=5
+Vector.CircleMinRadius=32
+Vector.CircleEndOnMinRadius=yes
+Vector.Origin=Target
+
+============================================================
+MoveTo 模式（FLH 强制位移）
+============================================================
+抛射体自身 FLH 坐标系下的每帧位移。自动等效 Force=yes。
+
+Vector.MoveTo=F,L,H
+  FLH 坐标系位移向量（lepton/step）。
+  F=前进方向，L=左方向，H=高度方向。
+  默认 0,0,0（不启用 MoveTo 模式）。
+
+Vector.GrowRate=F,L,H
+  每帧增量（lepton/step）。随时间缩放 MoveTo，产生呼吸/螺旋效果。
+  只计算运动帧（受 TimeStep 约束）。
+  默认 0,0,0。
+
+Vector.AnglePerFrame=N
+  每帧自增角度（°/step）。叠加到当前 FLH 朝向上，使位移向量持续旋转。
+  0 = 跟随物体当前朝向；非 0 = 画圆/螺旋。
+  默认 0。
+
+--- 示例：左侧切向偏移（直线）---
+[StraightLeft]
+Duration=200
+Vector.MoveTo=0,100,0
+
+--- 示例：自旋画圆（绕自身）---
+[SelfCircle]
+Duration=400
+Vector.MoveTo=0,100,0
+Vector.AnglePerFrame=5
+
+--- 示例：绕 Target 画圆（配合 Origin=Target）---
+[CircleTarget]
+Duration=400
+Vector.MoveTo=100,0,0
+Vector.AnglePerFrame=5
+Vector.Origin=Target
+
+--- 示例：呼吸效果（位移逐渐缩小）---
+[ShrinkMove]
+Duration=200
+Vector.MoveTo=100,100,100
+Vector.GrowRate=-1,-1,-1
+
+============================================================
+Speed 模式（直线追踪）
+============================================================
+每帧取当前位置到 TargetFLH 目标点的方向，以 Speed 速度移动。
+
+Vector.TargetFLH=F,L,H
+  目标点（FLH 坐标系，相对 Origin）。
+  默认 0,0,0。
+
+Vector.TargetOffsetF=Min,Max
+Vector.TargetOffsetL=Min,Max
+Vector.TargetOffsetH=Min,Max
+  目标随机偏移范围。获得 AE 时随机一次，之后固定。
+  默认 0,0。
+
+Vector.ReachTarget=yes/no
+  yes = 根据剩余 Duration 自动计算速度，保证到达目标点。
+       此时 InitialSpeed/Acceleration/MaxSpeed/MinSpeed 被忽略。
+  no  = 使用 Speed 模式，恒速/加速飞行，不论是否到达。
+  默认 no。
+
+Vector.InitialSpeed=N
+  初始线速度（lepton/step）。-1 = 读取单位 Speed 属性。
+  默认 -1。
+
+Vector.Acceleration=N
+  线加速度（lepton/step²）。每运动帧叠加。
+  受 TimeStep 约束。
+  默认 0。
+
+Vector.MaxSpeed=N
+  最大速度钳位。-1 = 不限。
+  默认 -1。
+
+Vector.MinSpeed=N
+  最小速度钳位。-1 = 不限。允许设 0 为静止或负值为反向。
+  默认 -1。
+
+--- 示例：恒速直线飞行 ---
+[FlyStraight]
+Duration=300
+Vector.TargetFLH=5000,0,5000
+Vector.InitialSpeed=40
+Vector.Origin=Launcher
+
+--- 示例：加速飞行 + 限速 ---
+[AccelFly]
+Duration=200
+Vector.TargetFLH=0,0,5000
+Vector.InitialSpeed=10
+Vector.Acceleration=2
+Vector.MaxSpeed=100
+Vector.Origin=FLH
+Vector.OriginFLH=0,512,0
+
+--- 示例：到达目标后冻结 ---
+[ReachAndFreeze]
+Duration=320
+Vector.TargetFLH=3000,0,3000
+Vector.Origin=Launcher
+Vector.ReachTarget=yes
+
+============================================================
+参考系（Origin 详细说明）
+============================================================
+
+FLH
+  F 轴 = 抛射体的 Velocity 方向（Techno 用 TurretFacing）
+  L 轴 = F 轴左侧 90°
+  原点 = 抛射体坐标 + OriginFLH 偏移（Fixed once at OnStart）
+  适用：物体自身朝向的位移（前进/侧移/升降）
+
+Launcher
+  F 轴 = 发射者 → 抛射体连线
+  L 轴 = F 轴左侧 90°
+  原点 = 发射者坐标（每帧刷新，除非 NoUpdate）
+  NoUpdate 默认 yes（锁定发射瞬间位置）
+
+Target
+  F 轴 = 目标 → 抛射体连线
+  L 轴 = F 轴左侧 90°
+  原点 = 目标坐标（优先 pBullet->Target，次选 Owner->Target）
+  每帧刷新，除非 NoUpdate
+
+Source
+  F 轴 = AE 来源单位 → 抛射体连线
+  L 轴 = F 轴左侧 90°
+  原点 = AE 来源单位坐标（每帧刷新，除非 NoUpdate）
+
+所有模式下 F/L 轴均只使用 XY 分量计算，Z 不纳入以避免倾斜坐标系。
+
+============================================================
+继承自 EffectData 的通用标签
+============================================================
+
+Duration=N
+  AE 持续时间（帧）。
+
+HoldDuration=yes/no
+  yes = Duration 到期后保持 AE 不销毁。
+  Duration=-1 默认 yes，Duration>0 需显式 no。
+  默认 yes。
+
+Next=AE_SECTION_NAME
+  当前 AE 结束后自动附加的下一个 AE。
+
+AttachOnceInTechnoType=yes/no
+  同类型单位只附加一次。
+
+Vector.Enable=yes/no
+  手动启用/禁用。默认自动判断（有位移参数时自动启用）。
+
+============================================================
+叠加规则
+============================================================
+多个带 Vector 效果的 AE 可同时附加到一个对象上。
+每个 Vector 独立计算位移向量，最终叠加后一次 SetLocation。
+Facing/Spin 等取第一个活跃 Vector 的值。
+
+============================================================
+测试 INI 示例（完整流程）
+============================================================
+
+[AAHeatSeeker2]
+AttachEffectTypes=VECTOR
+ROT=100
+
+[VECTOR]              ; 第一段：直线飞到目标附近
+Duration=35
+Vector.TargetFLH=700,0,600
+Vector.Origin=Target
+Vector.Force=yes
+Vector.ReachTarget=yes
+Next=CIRCLE
+
+[CIRCLE]              ; 第二段：绕目标画圆
+Duration=400
+Vector.CircleRadius=512
+Vector.CircleAnglePerFrame=5
+Vector.Origin=Target

--- a/src/Ext/BulletType/BulletStatus.h
+++ b/src/Ext/BulletType/BulletStatus.h
@@ -207,6 +207,7 @@ public:
 			// 位移向量
 			.Process(this->VectorForced)
 			.Process(this->_vectorResult)
+			.Process(this->_vectorStartPos)
 			// 碰撞引信
 			.Process(this->_proximity)
 			.Process(this->_activeProximity)
@@ -282,6 +283,7 @@ private:
 
 	// 向量位移
 	VectorResult _vectorResult{};
+	CoordStruct _vectorStartPos{};       // Force 模式起始位置快照
 
 	// 碰撞引信配置
 	ProximityData* _proximityData = nullptr;

--- a/src/Ext/BulletType/Status/Vector.cpp
+++ b/src/Ext/BulletType/Status/Vector.cpp
@@ -1,4 +1,4 @@
-﻿#include "../BulletStatus.h"
+#include "../BulletStatus.h"
 
 #include <Ext/Helper/FLH.h>
 #include <Ext/Helper/Physics.h>
@@ -11,17 +11,14 @@ void BulletStatus::OnUpdate_Vector()
 	if (CaptureByBlackHole)
 		return;
 
-	_vectorResult = AEManager()->MarginVectorOffset();
-	VectorForced = !_vectorResult.MoveDisp.IsEmpty();
+	// 记录起始位置（Force 模式用）
+	_vectorStartPos = pBullet->GetCoords();
 
-	// 检查是否有 Freeze，有则不设 Velocity（Freeze 在 OnUpdateEnd 处理）
-	if (!_vectorResult.Freeze && !_vectorResult.MoveDisp.IsEmpty())
-	{
-		// 设置 Velocity = 位移方向，让引擎协作移动抛射体
-		pBullet->Velocity.X = static_cast<double>(_vectorResult.MoveDisp.X);
-		pBullet->Velocity.Y = static_cast<double>(_vectorResult.MoveDisp.Y);
-		pBullet->Velocity.Z = static_cast<double>(_vectorResult.MoveDisp.Z);
-	}
+	_vectorResult = AEManager()->MarginVectorOffset();
+	VectorForced = _vectorResult.Force;
+
+	// Force 模式：不设 Velocity，位置由 OnUpdateEnd 的 SetLocation 接管
+	// 无论 ROT=1 还是 ROT>1，引擎轨迹计算都会被 SetLocation 覆盖
 }
 
 void BulletStatus::OnUpdateEnd_Vector(CoordStruct& sourcePos)
@@ -30,46 +27,25 @@ void BulletStatus::OnUpdateEnd_Vector(CoordStruct& sourcePos)
 	if (CaptureByBlackHole)
 		return;
 
+	// Freeze 优先：暴力锁定位置（不需要 VectorForced）
+	if (_vectorResult.Freeze && !_vectorResult.FrozenPos.IsEmpty())
+	{
+		pBullet->SetLocation(_vectorResult.FrozenPos);
+		pBullet->SourceCoords = _vectorResult.FrozenPos;
+		sourcePos = _vectorResult.FrozenPos;
+		return;
+	}
+
 	if (VectorForced)
 	{
-		// Freeze + Force: 强制把抛射体拉回冻结位置（Freeze 场景仍需 SetLocation）
-		if (_vectorResult.Freeze && !_vectorResult.FrozenPos.IsEmpty())
-		{
-			pBullet->SetLocation(_vectorResult.FrozenPos);
-			pBullet->SourceCoords = _vectorResult.FrozenPos;
-			sourcePos = _vectorResult.FrozenPos;
-			return;
-		}
-
-		// 抛射体撞到地面
-		bool canMove = pBullet->GetHeight() > 0;
-		// 检查悬崖
-		if (canMove)
-		{
-			CoordStruct nextCellPos = CoordStruct::Empty;
-			bool onBridge = false;
-			switch (CanMoveTo(sourcePos, _vectorResult.MoveDisp, _vectorResult.CanPassBuilding, nextCellPos, onBridge))
-			{
-			case PassError::UNDERGROUND:
-			case PassError::HITWALL:
-			case PassError::HITBUILDING:
-			case PassError::DOWNBRIDGE:
-			case PassError::UPBRIDEG:
-				canMove = false;
-				break;
-			}
-		}
-		if (!canMove)
-		{
-			// 原地爆炸
-			TakeDamage();
-		}
-		else
-		{
-			// 被黑洞吸走
-			pBullet->SetLocation(_vectorResult.MoveDisp);
-			// 修改了位置所以更新位置
-			sourcePos = _vectorResult.MoveDisp;
-		}
+		// Force 模式：直接 SetLocation，彻底跳过引擎轨迹计算
+		// 用 OnUpdate 快照的起始位置 + Vector 计算出的位移 = 引擎干预前的正确位置
+		CoordStruct desiredPos;
+		desiredPos.X = _vectorStartPos.X + _vectorResult.MoveDisp.X;
+		desiredPos.Y = _vectorStartPos.Y + _vectorResult.MoveDisp.Y;
+		desiredPos.Z = _vectorStartPos.Z + _vectorResult.MoveDisp.Z;
+		pBullet->SetLocation(desiredPos);
+		pBullet->SourceCoords = desiredPos;
+		sourcePos = desiredPos;
 	}
 }

--- a/src/Ext/EffectType/AttachEffectData.h
+++ b/src/Ext/EffectType/AttachEffectData.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <algorithm>
 #include <string>

--- a/src/Ext/EffectType/AttachEffectData.h
+++ b/src/Ext/EffectType/AttachEffectData.h
@@ -28,6 +28,8 @@
 #include "Effect/StackData.h"
 #include "Effect/StandData.h"
 #include "Effect/VectorData.h"
+#include "Effect/TurretSpinData.h"
+#include "Effect/BodySpinData.h"
 #include "Effect/VampireData.h"
 // State Effects
 #include <Ext/StateType/State/AntiBulletData.h>
@@ -170,6 +172,8 @@ public:
 	EFFECT_VAR_DEFINE(Stack);
 	EFFECT_VAR_DEFINE(Stand);
 	EFFECT_VAR_DEFINE(Vector);
+	EFFECT_VAR_DEFINE(TurretSpin);
+	EFFECT_VAR_DEFINE(BodySpin);
 	EFFECT_VAR_DEFINE(Vampire);
 	// State Effects
 	EFFECT_VAR_DEFINE(AntiBullet);
@@ -213,6 +217,8 @@ public:
 		EFFECT_VAR_READ(Stack);
 		EFFECT_VAR_READ(Stand);
 		EFFECT_VAR_READ(Vector);
+		EFFECT_VAR_READ(TurretSpin);
+		EFFECT_VAR_READ(BodySpin);
 		EFFECT_VAR_READ(Vampire);
 		// State Effects
 		EFFECT_VAR_READ(AntiBullet);
@@ -240,6 +246,8 @@ public:
 		// 替身要放在第一位，状态类型会附加状态给替身，此时若替身没有初始化，整个AE都会被判定为失效
 		EFFECT_VAR_SCRIPT_NAME(Stand);
 		EFFECT_VAR_SCRIPT_NAME(Vector);
+		EFFECT_VAR_SCRIPT_NAME(TurretSpin);
+		EFFECT_VAR_SCRIPT_NAME(BodySpin);
 
 		EFFECT_VAR_SCRIPT_NAME(Animation);
 		EFFECT_VAR_SCRIPT_NAME(AttackBeacon);
@@ -307,6 +315,8 @@ public:
 			EFFECT_VAR_PROCESS(Stack)
 			EFFECT_VAR_PROCESS(Stand)
 			EFFECT_VAR_PROCESS(Vector)
+			EFFECT_VAR_PROCESS(TurretSpin)
+			EFFECT_VAR_PROCESS(BodySpin)
 			EFFECT_VAR_PROCESS(Vampire)
 			// State Effects
 			EFFECT_VAR_PROCESS(AntiBullet)

--- a/src/Ext/EffectType/Effect/AutoWeaponEffect.cpp
+++ b/src/Ext/EffectType/Effect/AutoWeaponEffect.cpp
@@ -24,6 +24,17 @@ void AutoWeaponEffect::SetupFakeTargetToBullet(int index, int burst, BulletClass
 	}
 }
 
+static CoordStruct s_bulletMoveTo{};
+
+void AutoWeaponEffect::SetupBulletAtProjectile(int index, int burst, BulletClass*& pBullet, AbstractClass*& pTarget)
+{
+	if (!s_bulletMoveTo.IsEmpty())
+	{
+		pBullet->SetLocation(s_bulletMoveTo);
+		s_bulletMoveTo = {};
+	}
+}
+
 
 bool AutoWeaponEffect::CheckROF(WeaponTypeClass* pWeapon, WeaponTypeExt::TypeData* weaponData)
 {
@@ -97,14 +108,13 @@ bool AutoWeaponEffect::TryGetShooterAndTarget(TechnoClass* pReceiverOwner, House
 	// 设定目标
 	if (Data->IsAttackerMark)
 	{
-		// IsAttackerMark=yes时ReceiverAttack和ReceiverOwnBullet默认值为no
-		// 若无显式修改，此时应为攻击者朝AE附属对象进行攻击
-		// 只有显式修改 ReceiverAttack时，说明是由AE附属对象朝向攻击者攻击
-		// 修改目标为攻击者
 		if (Data->ReceiverAttack)
 		{
-			pTarget = AE->pSource;
-
+			// 来源是抛射体广播：目标设为抛射体坐标（通过 warheadLocation 传入）
+			if (AE->FromWarhead)
+				pTarget = nullptr; // 触发假目标，MakeFakeTarget 会用 WarheadLocation
+			else
+				pTarget = AE->pSource;
 		}
 	}
 	else if (Data->FireToTarget)
@@ -126,27 +136,35 @@ bool AutoWeaponEffect::TryGetShooterAndTarget(TechnoClass* pReceiverOwner, House
 ObjectClass* AutoWeaponEffect::MakeFakeTarget(HouseClass* pHouse, ObjectClass* pShooter, CoordStruct fireFLH, CoordStruct targetFLH)
 {
 	CoordStruct targetPos;
-	CoordStruct location = pShooter->GetCoords();
-	DirStruct dir;
-	// 确定假想敌的位置
-	if (Data->IsOnWorld)
+	// 抛射体广播：目标基于抛射体坐标（WarheadLocation）
+	if (AE->FromWarhead)
 	{
-		// 绑定世界坐标，以射手为参考移动位置
-		targetPos = GetFLHAbsoluteCoords(location, targetFLH, dir);
+		targetPos = AE->WarheadLocation + targetFLH;
 	}
 	else
 	{
-		TechnoClass* pShooterTechno = nullptr;
-		BulletClass* pShooterBullet = nullptr;
-		if (CastToTechno(pShooter, pShooterTechno))
+		CoordStruct location = pShooter->GetCoords();
+		DirStruct dir;
+		// 确定假想敌的位置
+		if (Data->IsOnWorld)
 		{
-			// 以射手为参考获取相对位置
-			targetPos = GetFLHAbsoluteCoords(pShooterTechno, targetFLH, Data->IsOnTurret);
-		}
-		else if (CastToBullet(pShooter, pShooterBullet))
-		{
-			dir = Facing(pBullet, location);
+			// 绑定世界坐标，以射手为参考移动位置
 			targetPos = GetFLHAbsoluteCoords(location, targetFLH, dir);
+		}
+		else
+		{
+			TechnoClass* pShooterTechno = nullptr;
+			BulletClass* pShooterBullet = nullptr;
+			if (CastToTechno(pShooter, pShooterTechno))
+			{
+				// 以射手为参考获取相对位置
+				targetPos = GetFLHAbsoluteCoords(pShooterTechno, targetFLH, Data->IsOnTurret);
+			}
+			else if (CastToBullet(pShooter, pShooterBullet))
+			{
+				dir = Facing(pBullet, location);
+				targetPos = GetFLHAbsoluteCoords(location, targetFLH, dir);
+			}
 		}
 	}
 	if (!targetPos.IsEmpty())
@@ -283,6 +301,11 @@ void AutoWeaponEffect::OnUpdate()
 						pTarget = MakeFakeTarget(pReceiverHouse, pShooter, data.FireFLH, data.TargetFLH);
 						callback = SetupFakeTargetToBullet;
 					}
+					else if (AE->FromWarhead && Data->IsAttackerMark && !Data->ReceiverAttack)
+					{
+						s_bulletMoveTo = AE->WarheadLocation;
+						callback = SetupBulletAtProjectile;
+					}
 					if (pTarget)
 					{
 						// 如果攻击者是子机，调整攻击者为母鸡
@@ -346,6 +369,11 @@ void AutoWeaponEffect::OnUpdate()
 							{
 								pTempTarget = MakeFakeTarget(pReceiverHouse, pShooter, data.FireFLH, data.TargetFLH);
 								callback = SetupFakeTargetToBullet;
+							}
+							else if (AE->FromWarhead && Data->IsAttackerMark && !Data->ReceiverAttack)
+							{
+								s_bulletMoveTo = AE->WarheadLocation;
+								callback = SetupBulletAtProjectile;
 							}
 							if (pTempTarget)
 							{

--- a/src/Ext/EffectType/Effect/AutoWeaponEffect.h
+++ b/src/Ext/EffectType/Effect/AutoWeaponEffect.h
@@ -31,6 +31,7 @@ public:
 	EFFECT_SCRIPT(AutoWeapon);
 
 	static void SetupFakeTargetToBullet(int index, int burst, BulletClass*& pBullet, AbstractClass*& pTarget);
+	static void SetupBulletAtProjectile(int index, int burst, BulletClass*& pBullet, AbstractClass*& pTarget);
 
 	virtual void Clean() override
 	{

--- a/src/Ext/EffectType/Effect/BodySpinData.h
+++ b/src/Ext/EffectType/Effect/BodySpinData.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <GeneralStructures.h>
+
+#include <Common/INI/INIConfig.h>
+
+#include "EffectData.h"
+
+class BodySpinData : public EffectData
+{
+public:
+	int Speed = 0;
+	int SweepPeriod = 0;
+
+	BodySpinData() : EffectData()
+	{ }
+
+	virtual void Read(INIBufferReader* reader) override
+	{
+		Read(reader, "BodySpin.");
+	}
+
+	virtual void Read(INIBufferReader* reader, std::string title) override
+	{
+		EffectData::Read(reader, title);
+
+		Speed = reader->Get(title + "Speed", Speed);
+		SweepPeriod = reader->Get(title + "SweepPeriod", SweepPeriod);
+
+		Enable = Speed != 0 || SweepPeriod > 0;
+	}
+
+	template <typename T>
+	bool Serialize(T& stream)
+	{
+		stream
+			.Process(Speed)
+			.Process(SweepPeriod)
+			;
+		return true;
+	}
+
+	virtual bool Load(ExStreamReader& stream, bool registerForChange) override
+	{
+		EffectData::Load(stream, registerForChange);
+		return this->Serialize(stream);
+	}
+
+	virtual bool Save(ExStreamWriter& stream) const override
+	{
+		EffectData::Save(stream);
+		return const_cast<BodySpinData*>(this)->Serialize(stream);
+	}
+};

--- a/src/Ext/EffectType/Effect/BodySpinEffect.cpp
+++ b/src/Ext/EffectType/Effect/BodySpinEffect.cpp
@@ -1,0 +1,1 @@
+#include "BodySpinEffect.h"

--- a/src/Ext/EffectType/Effect/BodySpinEffect.h
+++ b/src/Ext/EffectType/Effect/BodySpinEffect.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "../EffectScript.h"
+#include "BodySpinData.h"
+
+class BodySpinEffect : public EffectScript
+{
+public:
+	EFFECT_SCRIPT(BodySpin);
+};

--- a/src/Ext/EffectType/Effect/BroadcastEffect.cpp
+++ b/src/Ext/EffectType/Effect/BroadcastEffect.cpp
@@ -10,10 +10,18 @@ void BroadcastEffect::FindAndAttach(BroadcastEntity data, HouseClass* pHouse)
 	CoordStruct location = pObject->GetCoords();
 	ObjectClass* pSource = AE->pSource;
 	HouseClass* pSourceHouse = AE->pSourceHouse;
+	CoordStruct projectileLocation{};
 	if (AEData.ReceiverOwn || !pSource || !pSourceHouse)
 	{
 		pSource = pObject;
 		pSourceHouse = pHouse;
+	}
+	// 广播持有者是抛射体：来源改为发射者（满足 pSource 必须是 TechnoClass 约束），坐标另传
+	if (pBullet)
+	{
+		pSource = pBullet->Owner;
+		pSourceHouse = pHouse;
+		projectileLocation = pObject->GetCoords();
 	}
 	// 搜索单位
 	if (Data->AffectTechno)
@@ -22,7 +30,7 @@ void BroadcastEffect::FindAndAttach(BroadcastEntity data, HouseClass* pHouse)
 		FindTechnoOnMark([&](TechnoClass* pTarget, AttachEffect* aeManager)
 			{
 				// 赋予AE
-				aeManager->Attach(data.Types, data.AttachChances, false, pSource, pSourceHouse);
+				aeManager->Attach(data.Types, data.AttachChances, false, pSource, pSourceHouse, projectileLocation);
 				attachCount++;
 				if (Data->MaxAttachTechno > 0 && attachCount >= Data->MaxAttachTechno)
 				{
@@ -38,7 +46,7 @@ void BroadcastEffect::FindAndAttach(BroadcastEntity data, HouseClass* pHouse)
 		FindBulletOnMark([&](BulletClass* pTarget, AttachEffect* aeManager)
 			{
 				// 赋予AE
-				aeManager->Attach(data.Types, data.AttachChances, false, pSource, pSourceHouse);
+				aeManager->Attach(data.Types, data.AttachChances, false, pSource, pSourceHouse, projectileLocation);
 				attachCount++;
 				if (Data->MaxAttachBullet > 0 && attachCount >= Data->MaxAttachBullet)
 				{

--- a/src/Ext/EffectType/Effect/TurretSpinData.h
+++ b/src/Ext/EffectType/Effect/TurretSpinData.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <GeneralStructures.h>
+
+#include <Common/INI/INIConfig.h>
+
+#include "EffectData.h"
+
+class TurretSpinData : public EffectData
+{
+public:
+	int Speed = 0;
+	int SweepPeriod = 0;
+
+	TurretSpinData() : EffectData()
+	{ }
+
+	virtual void Read(INIBufferReader* reader) override
+	{
+		Read(reader, "TurretSpin.");
+	}
+
+	virtual void Read(INIBufferReader* reader, std::string title) override
+	{
+		EffectData::Read(reader, title);
+
+		Speed = reader->Get(title + "Speed", Speed);
+		SweepPeriod = reader->Get(title + "SweepPeriod", SweepPeriod);
+
+		Enable = Speed != 0 || SweepPeriod > 0;
+	}
+
+	template <typename T>
+	bool Serialize(T& stream)
+	{
+		stream
+			.Process(Speed)
+			.Process(SweepPeriod)
+			;
+		return true;
+	}
+
+	virtual bool Load(ExStreamReader& stream, bool registerForChange) override
+	{
+		EffectData::Load(stream, registerForChange);
+		return this->Serialize(stream);
+	}
+
+	virtual bool Save(ExStreamWriter& stream) const override
+	{
+		EffectData::Save(stream);
+		return const_cast<TurretSpinData*>(this)->Serialize(stream);
+	}
+};

--- a/src/Ext/EffectType/Effect/TurretSpinEffect.cpp
+++ b/src/Ext/EffectType/Effect/TurretSpinEffect.cpp
@@ -1,0 +1,1 @@
+#include "TurretSpinEffect.h"

--- a/src/Ext/EffectType/Effect/TurretSpinEffect.h
+++ b/src/Ext/EffectType/Effect/TurretSpinEffect.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "../EffectScript.h"
+#include "TurretSpinData.h"
+
+// 空壳：框架需要此类存在以创建 AE 组件
+// 实际旋转逻辑由 TechnoStatus::OnUpdate_TurretSpin 驱动
+class TurretSpinEffect : public EffectScript
+{
+public:
+	EFFECT_SCRIPT(TurretSpin);
+};

--- a/src/Ext/EffectType/Effect/VectorData.h
+++ b/src/Ext/EffectType/Effect/VectorData.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <string>
 #include <vector>
@@ -13,168 +13,87 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-enum class VectorFacing : int
-{
-	Destination = 0, Target = 1, Initial = 2,
-};
-
-template <>
-inline bool Parser<VectorFacing>::TryParse(const char* pValue, VectorFacing* outValue)
-{
-	switch (toupper(static_cast<unsigned char>(*pValue)))
-	{
-	case 'T':
-		if (outValue) { *outValue = VectorFacing::Target; }
-		return true;
-	case 'I':
-		if (outValue) { *outValue = VectorFacing::Initial; }
-		return true;
-	default:
-		if (outValue) { *outValue = VectorFacing::Destination; }
-		return true;
-	}
-}
-
-enum class VectorRotateAxis : int
-{
-	X = 0, Y = 1, Z = 2,
-};
-
-template <>
-inline bool Parser<VectorRotateAxis>::TryParse(const char* pValue, VectorRotateAxis* outValue)
-{
-	switch (toupper(static_cast<unsigned char>(*pValue)))
-	{
-	case 'X':
-		if (outValue) { *outValue = VectorRotateAxis::X; }
-		return true;
-	case 'Y':
-		if (outValue) { *outValue = VectorRotateAxis::Y; }
-		return true;
-	default:
-		if (outValue) { *outValue = VectorRotateAxis::Z; }
-		return true;
-	}
-}
-
-inline CoordStruct RodriguesRotate(CoordStruct v, CoordStruct k, double angleDeg)
-{
-	double rad = angleDeg * M_PI / 180.0;
-	double c = std::cos(rad);
-	double s = std::sin(rad);
-	double t = 1.0 - c;
-
-	double kLen = std::sqrt(k.X * k.X + k.Y * k.Y + k.Z * k.Z);
-	if (kLen < 1e-6)
-	{
-		return v;
-	}
-	double kx = k.X / kLen;
-	double ky = k.Y / kLen;
-	double kz = k.Z / kLen;
-
-	CoordStruct result;
-	result.X = static_cast<int>(v.X * (kx * kx * t + c) + v.Y * (kx * ky * t - kz * s) + v.Z * (kx * kz * t + ky * s));
-	result.Y = static_cast<int>(v.X * (ky * kx * t + kz * s) + v.Y * (ky * ky * t + c) + v.Z * (ky * kz * t - kx * s));
-	result.Z = static_cast<int>(v.X * (kz * kx * t - ky * s) + v.Y * (kz * ky * t + kx * s) + v.Z * (kz * kz * t + c));
-	return result;
-}
-
-inline CoordStruct GetRotateAxis(VectorRotateAxis axis)
-{
-	switch (axis)
-	{
-	case VectorRotateAxis::X: return { 1, 0, 0 };
-	case VectorRotateAxis::Y: return { 0, 1, 0 };
-	case VectorRotateAxis::Z: return { 0, 0, 1 };
-	default: return { 0, 0, 1 };
-	}
-}
-
 class VectorData : public EffectData
 {
 public:
 	EFFECT_DATA(Vector);
 
-	CoordStruct TargetFLH{};
-	Point2D TargetRandF{};
-	Point2D TargetRandL{};
-	Point2D TargetRandH{};
-	bool ReachTarget = false;
+	// ========================================================================
+	// 通用设定
+	// ========================================================================
 
-	int StartSpeed = 0;
-	int EndSpeed = -1;
-	int Acceleration = 0;
-	int FrameStep = 1;
-	int SpeedOscillation = 0;
-	int SpeedOscFreq = 0;
-	int SpeedOscPhase = 0;
-
-	CoordStruct MoveTo{};
-	CoordStruct GrowRate{};
-	int GrowOscillationX = 0;
-	int GrowOscillationY = 0;
-	int GrowOscillationZ = 0;
-	int GrowOscFreqX = 0;
-	int GrowOscFreqY = 0;
-	int GrowOscFreqZ = 0;
-	int GrowOscPhaseX = 0;
-	int GrowOscPhaseY = 0;
-	int GrowOscPhaseZ = 0;
-	bool Force = false;
-	bool Freeze = false;
-
-	CoordStruct WaveAmplitude{};
-	CoordStruct WaveFrequency{};
-	CoordStruct WavePhase{};
-	CoordStruct WaveFreqAcceleration{};
-	CoordStruct WaveFreqEndSpeed{};
-	int WaveAmpOscillation = 0;
-	int WaveAmpOscFreq = 0;
-	int WaveAmpOscPhase = 0;
-	int WaveFreqOscillation = 0;
-	int WaveFreqOscFreq = 0;
-	int WaveFreqOscPhase = 0;
-
-	int AnglePerFrame = 0;
-	int Radius = 0;
-	VectorRotateAxis RotateAxis;
-	CoordStruct RotateDirection{};
-
-	int SpinRate = 0;
-	int SpinEndSpeed = -1;
-	int SpinAcceleration = 0;
-	VectorRotateAxis SpinAxis;
-	CoordStruct SpinDirection{};
-	int SpinOscillation = 0;
-	int SpinOscFreq = 0;
-	int SpinOscPhase = 0;
-
-	int TurretSpinRate = 0;
-	int TurretSpinEndSpeed = -1;
-	int TurretSpinAcceleration = 0;
-	VectorRotateAxis TurretSpinAxis;
-	CoordStruct TurretSpinDirection{};
-	int TurretSpinOscillation = 0;
-	int TurretSpinOscFreq = 0;
-	int TurretSpinOscPhase = 0;
-	bool FreeTurret = false;
-
-	VectorFacing Facing = VectorFacing::Destination;
+	int TimeStep = 1;
 
 	enum class VectorOrigin : int
 	{
-		World = 0, Target = 1, Launcher = 2, Self = 3, Realtime = 4, Source = 5, FLH = 6,
+		FLH = 0, Launcher = 1, Target = 2, Source = 3,
 	};
-	VectorOrigin Origin = VectorOrigin::Self;
+	VectorOrigin Origin = VectorOrigin::FLH;
 	CoordStruct OriginFLH{};
 	bool OriginNoUpdate = false;
+	bool Force = false;
+	bool Freeze = false;
+
+	// ========================================================================
+	// MoveTo 模式（纯 FLH 位移 + GrowRate）
+	// ========================================================================
+
+	CoordStruct MoveTo{};
+	CoordStruct GrowRate{};             // 每帧 FLH 增量（呼吸/螺旋/振幅）
+	double AnglePerFrame = 0.0;         // MoveTo 模式角度自增（°/step）
+
+	// ========================================================================
+	// Circle 模式（圆周，独立于 MoveTo）
+	// 三选二：Radius / Speed / AnglePerFrame，未设的一项自动推算
+	// 圆心 = Origin（同 Origin 标签，动态刷新除非 NoUpdate）
+	// ========================================================================
+
+	int CircleRadius = -1;              // 圆半径（lepton），-1=自动取当前XY距离
+	int CircleSpeed = 0;               // 线速度（lepton/step沿圆周），0=不由它推算
+	int CircleSpeedAcceleration = 0;   // 线速度每步加速度
+	int CircleMaxSpeed = 0;            // 线速度上限，0=不限
+	int CircleMinSpeed = 0;            // 线速度下限，0=不限
+	double CircleAnglePerFrame = 0.0;  // 角速度（°/step），0=不由它推算
+	double CircleAngleAcceleration = 0.0; // 角速度每步加速度
+	double CircleMaxAngle = 0.0;     // 角速度上限，0=不限
+	double CircleMinAngle = 0.0;     // 角速度下限，0=不限
+	int CircleRadiusGrow = 0;          // 半径每步增长量（lepton/step），正=外扩，负=内缩
+	int CircleMaxRadius = 0;           // 半径上限，0=不限
+	int CircleMinRadius = 0;           // 半径下限，0=不限
+	bool CircleEndOnMaxRadius = false; // 半径达到上限时结束 AE
+	bool CircleEndOnMinRadius = false; // 半径达到下限时结束 AE
+
+	// ========================================================================
+	// Speed 模式（直线追踪 + 加速度）
+	// ========================================================================
+
+	CoordStruct TargetFLH{};
+	int TargetOffsetFMin = 0;
+	int TargetOffsetFMax = 0;
+	int TargetOffsetLMin = 0;
+	int TargetOffsetLMax = 0;
+	int TargetOffsetHMin = 0;
+	int TargetOffsetHMax = 0;
+
+	int InitialSpeed = -1;              // -1 = 读取单位 Speed
+	int MaxSpeed = -1;                  // -1 = 不限
+	int MinSpeed = -1;                  // -1 = 不限
+	int Acceleration = 0;               // 每帧速度增量
+
+	// ========================================================================
+	// ReachTarget 模式（剩余帧数强制到达）
+	// ========================================================================
+
+	bool ReachTarget = false;           // 与 TargetFLH 配合使用
+
+	// ========================================================================
+	// 内部
+	// ========================================================================
 
 	VectorData() : EffectData()
 	{
 		AffectBuilding = false;
 	}
-
 
 	virtual void Read(INIBufferReader* reader) override
 	{
@@ -185,88 +104,80 @@ public:
 	{
 		EffectData::Read(reader, title);
 
-		TargetFLH = reader->Get(title + "TargetFLH", TargetFLH);
-		TargetRandF = reader->Get(title + "TargetRandF", TargetRandF);
-		TargetRandL = reader->Get(title + "TargetRandL", TargetRandL);
-		TargetRandH = reader->Get(title + "TargetRandH", TargetRandH);
-		ReachTarget = reader->Get(title + "ReachTarget", ReachTarget);
+		// --- 通用 ---
+		TimeStep = reader->Get(title + "TimeStep", 1);
+		if (TimeStep < 1) TimeStep = 1;
 
-		StartSpeed = reader->Get(title + "StartSpeed", StartSpeed);
-		EndSpeed = reader->Get(title + "EndSpeed", EndSpeed);
-		Acceleration = reader->Get(title + "Acceleration", Acceleration);
-		FrameStep = reader->Get(title + "FrameStep", FrameStep);
-		if (FrameStep < 1) FrameStep = 1;
-		SpeedOscillation = reader->Get(title + "SpeedOscillation", SpeedOscillation);
-		SpeedOscFreq = reader->Get(title + "SpeedOscFreq", SpeedOscFreq);
-		SpeedOscPhase = reader->Get(title + "SpeedOscPhase", SpeedOscPhase);
+		std::string originStr = reader->Get(title + "Origin", std::string{ "FLH" });
+		if (originStr == "Launcher") Origin = VectorOrigin::Launcher;
+		else if (originStr == "Target") Origin = VectorOrigin::Target;
+		else if (originStr == "Source") Origin = VectorOrigin::Source;
+		else Origin = VectorOrigin::FLH;
 
-		MoveTo = reader->Get(title + "MoveTo", MoveTo);
-		GrowRate = reader->Get(title + "GrowRate", GrowRate);
-		GrowOscillationX = reader->Get(title + "GrowOscillationX", GrowOscillationX);
-		GrowOscillationY = reader->Get(title + "GrowOscillationY", GrowOscillationY);
-		GrowOscillationZ = reader->Get(title + "GrowOscillationZ", GrowOscillationZ);
-		GrowOscFreqX = reader->Get(title + "GrowOscFreqX", GrowOscFreqX);
-		GrowOscFreqY = reader->Get(title + "GrowOscFreqY", GrowOscFreqY);
-		GrowOscFreqZ = reader->Get(title + "GrowOscFreqZ", GrowOscFreqZ);
-		GrowOscPhaseX = reader->Get(title + "GrowOscPhaseX", GrowOscPhaseX);
-		GrowOscPhaseY = reader->Get(title + "GrowOscPhaseY", GrowOscPhaseY);
-		GrowOscPhaseZ = reader->Get(title + "GrowOscPhaseZ", GrowOscPhaseZ);
+		OriginFLH = reader->Get(title + "OriginFLH", OriginFLH);
+		// Origin=Launcher 时 NoUpdate 默认 yes，锁定发射者坐标
+		if (Origin == VectorOrigin::Launcher)
+			OriginNoUpdate = true;
+		OriginNoUpdate = reader->Get(title + "OriginNoUpdate", OriginNoUpdate);
 		Force = reader->Get(title + "Force", Force);
 		Freeze = reader->Get(title + "Freeze", Freeze);
 
-		WaveAmplitude = reader->Get(title + "WaveAmplitude", WaveAmplitude);
-		WaveFrequency = reader->Get(title + "WaveFrequency", WaveFrequency);
-		WavePhase = reader->Get(title + "WavePhase", WavePhase);
-		WaveFreqAcceleration = reader->Get(title + "WaveFreqAcceleration", WaveFreqAcceleration);
-		WaveFreqEndSpeed = reader->Get(title + "WaveFreqEndSpeed", WaveFreqEndSpeed);
-		WaveAmpOscillation = reader->Get(title + "WaveAmpOscillation", WaveAmpOscillation);
-		WaveAmpOscFreq = reader->Get(title + "WaveAmpOscFreq", WaveAmpOscFreq);
-		WaveAmpOscPhase = reader->Get(title + "WaveAmpOscPhase", WaveAmpOscPhase);
-		WaveFreqOscillation = reader->Get(title + "WaveFreqOscillation", WaveFreqOscillation);
-		WaveFreqOscFreq = reader->Get(title + "WaveFreqOscFreq", WaveFreqOscFreq);
-		WaveFreqOscPhase = reader->Get(title + "WaveFreqOscPhase", WaveFreqOscPhase);
+		// --- MoveTo ---
+		MoveTo = reader->Get(title + "MoveTo", MoveTo);
+		GrowRate = reader->Get(title + "GrowRate", GrowRate);
+		AnglePerFrame = reader->Get(title + "AnglePerFrame", 0.0);
 
-		AnglePerFrame = reader->Get(title + "AnglePerFrame", AnglePerFrame);
-		Radius = reader->Get(title + "Radius", Radius);
-		RotateAxis = reader->Get(title + "RotateAxis", RotateAxis);
-		RotateDirection = reader->Get(title + "RotateDirection", RotateDirection);
+		// --- Circle ---
+		CircleRadius = reader->Get(title + "CircleRadius", -1);
+		CircleSpeed = reader->Get(title + "CircleSpeed", 0);
+		CircleSpeedAcceleration = reader->Get(title + "CircleSpeedAcceleration", 0);
+		CircleMaxSpeed = reader->Get(title + "CircleMaxSpeed", 0);
+		CircleMinSpeed = reader->Get(title + "CircleMinSpeed", 0);
+		CircleAnglePerFrame = reader->Get(title + "CircleAnglePerFrame", 0.0);
+		CircleAngleAcceleration = reader->Get(title + "CircleAngleAcceleration", 0.0);
+		CircleMaxAngle = reader->Get(title + "CircleMaxAngle", 0.0);
+		CircleMinAngle = reader->Get(title + "CircleMinAngle", 0.0);
+		CircleRadiusGrow = reader->Get(title + "CircleRadiusGrow", 0);
+		CircleMaxRadius = reader->Get(title + "CircleMaxRadius", 0);
+		CircleMinRadius = reader->Get(title + "CircleMinRadius", 0);
+		CircleEndOnMaxRadius = reader->Get(title + "CircleEndOnMaxRadius", false);
+		CircleEndOnMinRadius = reader->Get(title + "CircleEndOnMinRadius", false);
 
-		SpinRate = reader->Get(title + "SpinRate", SpinRate);
-		SpinEndSpeed = reader->Get(title + "SpinEndSpeed", SpinEndSpeed);
-		SpinAcceleration = reader->Get(title + "SpinAcceleration", SpinAcceleration);
-		SpinAxis = reader->Get(title + "SpinAxis", SpinAxis);
-		SpinDirection = reader->Get(title + "SpinDirection", SpinDirection);
-		SpinOscillation = reader->Get(title + "SpinOscillation", SpinOscillation);
-		SpinOscFreq = reader->Get(title + "SpinOscFreq", SpinOscFreq);
-		SpinOscPhase = reader->Get(title + "SpinOscPhase", SpinOscPhase);
+		// --- Speed / ReachTarget ---
+		TargetFLH = reader->Get(title + "TargetFLH", TargetFLH);
+		std::string targetOffsetFStr = reader->Get(title + "TargetOffsetF", std::string{ "" });
+		std::string targetOffsetLStr = reader->Get(title + "TargetOffsetL", std::string{ "" });
+		std::string targetOffsetHStr = reader->Get(title + "TargetOffsetH", std::string{ "" });
+		ParseMinMax(targetOffsetFStr, TargetOffsetFMin, TargetOffsetFMax);
+		ParseMinMax(targetOffsetLStr, TargetOffsetLMin, TargetOffsetLMax);
+		ParseMinMax(targetOffsetHStr, TargetOffsetHMin, TargetOffsetHMax);
+		ReachTarget = reader->Get(title + "ReachTarget", ReachTarget);
 
-		TurretSpinRate = reader->Get(title + "TurretSpinRate", TurretSpinRate);
-		TurretSpinEndSpeed = reader->Get(title + "TurretSpinEndSpeed", TurretSpinEndSpeed);
-		TurretSpinAcceleration = reader->Get(title + "TurretSpinAcceleration", TurretSpinAcceleration);
-		TurretSpinAxis = reader->Get(title + "TurretSpinAxis", TurretSpinAxis);
-		TurretSpinDirection = reader->Get(title + "TurretSpinDirection", TurretSpinDirection);
-		TurretSpinOscillation = reader->Get(title + "TurretSpinOscillation", TurretSpinOscillation);
-		TurretSpinOscFreq = reader->Get(title + "TurretSpinOscFreq", TurretSpinOscFreq);
-		TurretSpinOscPhase = reader->Get(title + "TurretSpinOscPhase", TurretSpinOscPhase);
-		FreeTurret = reader->Get(title + "FreeTurret", FreeTurret);
+		// --- 速度 ---
+		InitialSpeed = reader->Get(title + "InitialSpeed", -1);
+		MaxSpeed = reader->Get(title + "MaxSpeed", -1);
+		MinSpeed = reader->Get(title + "MinSpeed", -1);
+		Acceleration = reader->Get(title + "Acceleration", Acceleration);
 
-		Facing = reader->Get(title + "Facing", Facing);
+		Enable = !MoveTo.IsEmpty() || !TargetFLH.IsEmpty() || Force || Freeze
+			|| (CircleRadius > 0) || (CircleSpeed > 0) || (CircleAnglePerFrame > 0.0);
+	}
 
-		std::string originStr = reader->Get(title + "Origin", std::string{ "Self" });
-		if (originStr == "World") Origin = VectorOrigin::World;
-		else if (originStr == "Target") Origin = VectorOrigin::Target;
-		else if (originStr == "Launcher") Origin = VectorOrigin::Launcher;
-		else if (originStr == "Self") Origin = VectorOrigin::Self;
-		else if (originStr == "Realtime") Origin = VectorOrigin::Realtime;
-		else if (originStr == "Source") Origin = VectorOrigin::Source;
-		else if (originStr == "FLH") Origin = VectorOrigin::FLH;
-		else Origin = VectorOrigin::Self;
-
-		OriginFLH = reader->Get(title + "OriginFLH", OriginFLH);
-		OriginNoUpdate = reader->Get(title + "OriginNoUpdate", OriginNoUpdate);
-
-		Enable = !MoveTo.IsEmpty() || !TargetFLH.IsEmpty() || AnglePerFrame != 0 || Radius != 0
-			|| SpinRate != 0 || !WaveAmplitude.IsEmpty() || Force || Freeze;
+private:
+	static void ParseMinMax(const std::string& str, int& min, int& max)
+	{
+		if (str.empty()) return;
+		size_t commaPos = str.find(',');
+		if (commaPos != std::string::npos)
+		{
+			min = std::stoi(str.substr(0, commaPos));
+			max = std::stoi(str.substr(commaPos + 1));
+		}
+		else
+		{
+			min = std::stoi(str);
+			max = min;
+		}
 	}
 
 #pragma region save/load
@@ -274,74 +185,44 @@ public:
 	bool Serialize(T& stream)
 	{
 		stream
-			.Process(this->TargetFLH)
-			.Process(this->TargetRandF)
-			.Process(this->TargetRandL)
-			.Process(this->TargetRandH)
-			.Process(this->ReachTarget)
-
-			.Process(this->StartSpeed)
-			.Process(this->EndSpeed)
-			.Process(this->Acceleration)
-			.Process(this->FrameStep)
-			.Process(this->SpeedOscillation)
-			.Process(this->SpeedOscFreq)
-			.Process(this->SpeedOscPhase)
-
-			.Process(this->MoveTo)
-			.Process(this->GrowRate)
-			.Process(this->GrowOscillationX)
-			.Process(this->GrowOscillationY)
-			.Process(this->GrowOscillationZ)
-			.Process(this->GrowOscFreqX)
-			.Process(this->GrowOscFreqY)
-			.Process(this->GrowOscFreqZ)
-			.Process(this->GrowOscPhaseX)
-			.Process(this->GrowOscPhaseY)
-			.Process(this->GrowOscPhaseZ)
+			.Process(this->TimeStep)
+			.Process(this->Origin)
+			.Process(this->OriginFLH)
+			.Process(this->OriginNoUpdate)
 			.Process(this->Force)
 			.Process(this->Freeze)
 
-			.Process(this->WaveAmplitude)
-			.Process(this->WaveFrequency)
-			.Process(this->WavePhase)
-			.Process(this->WaveFreqAcceleration)
-			.Process(this->WaveFreqEndSpeed)
-			.Process(this->WaveAmpOscillation)
-			.Process(this->WaveAmpOscFreq)
-			.Process(this->WaveAmpOscPhase)
-			.Process(this->WaveFreqOscillation)
-			.Process(this->WaveFreqOscFreq)
-			.Process(this->WaveFreqOscPhase)
-
+			.Process(this->MoveTo)
+			.Process(this->GrowRate)
 			.Process(this->AnglePerFrame)
-			.Process(this->Radius)
-			.Process(this->RotateAxis)
-			.Process(this->RotateDirection)
+			.Process(this->CircleRadius)
+			.Process(this->CircleSpeed)
+			.Process(this->CircleSpeedAcceleration)
+			.Process(this->CircleMaxSpeed)
+			.Process(this->CircleMinSpeed)
+			.Process(this->CircleAnglePerFrame)
+			.Process(this->CircleAngleAcceleration)
+			.Process(this->CircleMaxAngle)
+			.Process(this->CircleMinAngle)
+			.Process(this->CircleRadiusGrow)
+			.Process(this->CircleMaxRadius)
+			.Process(this->CircleMinRadius)
+			.Process(this->CircleEndOnMaxRadius)
+			.Process(this->CircleEndOnMinRadius)
 
-			.Process(this->SpinRate)
-			.Process(this->SpinEndSpeed)
-			.Process(this->SpinAcceleration)
-			.Process(this->SpinAxis)
-			.Process(this->SpinDirection)
-			.Process(this->SpinOscillation)
-			.Process(this->SpinOscFreq)
-			.Process(this->SpinOscPhase)
+			.Process(this->TargetFLH)
+			.Process(this->TargetOffsetFMin)
+			.Process(this->TargetOffsetFMax)
+			.Process(this->TargetOffsetLMin)
+			.Process(this->TargetOffsetLMax)
+			.Process(this->TargetOffsetHMin)
+			.Process(this->TargetOffsetHMax)
+			.Process(this->ReachTarget)
 
-			.Process(this->TurretSpinRate)
-			.Process(this->TurretSpinEndSpeed)
-			.Process(this->TurretSpinAcceleration)
-			.Process(this->TurretSpinAxis)
-			.Process(this->TurretSpinDirection)
-			.Process(this->TurretSpinOscillation)
-			.Process(this->TurretSpinOscFreq)
-			.Process(this->TurretSpinOscPhase)
-			.Process(this->FreeTurret)
-
-			.Process(this->Facing)
-			.Process(this->Origin)
-			.Process(this->OriginFLH)
-			.Process(this->OriginNoUpdate);
+			.Process(this->InitialSpeed)
+			.Process(this->MaxSpeed)
+			.Process(this->MinSpeed)
+			.Process(this->Acceleration);
 		return stream.Success();
 	};
 

--- a/src/Ext/EffectType/Effect/VectorData.h
+++ b/src/Ext/EffectType/Effect/VectorData.h
@@ -40,7 +40,7 @@ public:
 
 	CoordStruct MoveTo{};
 	CoordStruct GrowRate{};             // 每帧 FLH 增量（呼吸/螺旋/振幅）
-	double AnglePerFrame = 0.0;         // MoveTo 模式角度自增（°/step）
+	double AnglePerStep = 0.0;         // MoveTo 模式角度自增（°/step）
 
 	// ========================================================================
 	// Circle 模式（圆周，独立于 MoveTo）
@@ -53,7 +53,7 @@ public:
 	int CircleSpeedAcceleration = 0;   // 线速度每步加速度
 	int CircleMaxSpeed = 0;            // 线速度上限，0=不限
 	int CircleMinSpeed = 0;            // 线速度下限，0=不限
-	double CircleAnglePerFrame = 0.0;  // 角速度（°/step），0=不由它推算
+	double CircleAnglePerStep = 0.0;  // 角速度（°/step），0=不由它推算
 	double CircleAngleAcceleration = 0.0; // 角速度每步加速度
 	double CircleMaxAngle = 0.0;     // 角速度上限，0=不限
 	double CircleMinAngle = 0.0;     // 角速度下限，0=不限
@@ -85,6 +85,9 @@ public:
 	// ========================================================================
 
 	bool ReachTarget = false;           // 与 TargetFLH 配合使用
+	int ArcHeight = 0;                  // ReachTarget 弧高（lepton），0=直线，正=上凸
+	bool AllowFallingDestroy = false;   // 向量结束时摔死
+	int FallingDestroyHeight = 2 * Unsorted::LevelHeight;   // 摔死高度
 
 	// ========================================================================
 	// 内部
@@ -115,9 +118,6 @@ public:
 		else Origin = VectorOrigin::FLH;
 
 		OriginFLH = reader->Get(title + "OriginFLH", OriginFLH);
-		// Origin=Launcher 时 NoUpdate 默认 yes，锁定发射者坐标
-		if (Origin == VectorOrigin::Launcher)
-			OriginNoUpdate = true;
 		OriginNoUpdate = reader->Get(title + "OriginNoUpdate", OriginNoUpdate);
 		Force = reader->Get(title + "Force", Force);
 		Freeze = reader->Get(title + "Freeze", Freeze);
@@ -125,7 +125,7 @@ public:
 		// --- MoveTo ---
 		MoveTo = reader->Get(title + "MoveTo", MoveTo);
 		GrowRate = reader->Get(title + "GrowRate", GrowRate);
-		AnglePerFrame = reader->Get(title + "AnglePerFrame", 0.0);
+		AnglePerStep = reader->Get(title + "AnglePerStep", 0.0);
 
 		// --- Circle ---
 		CircleRadius = reader->Get(title + "CircleRadius", -1);
@@ -133,7 +133,7 @@ public:
 		CircleSpeedAcceleration = reader->Get(title + "CircleSpeedAcceleration", 0);
 		CircleMaxSpeed = reader->Get(title + "CircleMaxSpeed", 0);
 		CircleMinSpeed = reader->Get(title + "CircleMinSpeed", 0);
-		CircleAnglePerFrame = reader->Get(title + "CircleAnglePerFrame", 0.0);
+		CircleAnglePerStep = reader->Get(title + "CircleAnglePerStep", 0.0);
 		CircleAngleAcceleration = reader->Get(title + "CircleAngleAcceleration", 0.0);
 		CircleMaxAngle = reader->Get(title + "CircleMaxAngle", 0.0);
 		CircleMinAngle = reader->Get(title + "CircleMinAngle", 0.0);
@@ -152,6 +152,9 @@ public:
 		ParseMinMax(targetOffsetLStr, TargetOffsetLMin, TargetOffsetLMax);
 		ParseMinMax(targetOffsetHStr, TargetOffsetHMin, TargetOffsetHMax);
 		ReachTarget = reader->Get(title + "ReachTarget", ReachTarget);
+		ArcHeight = reader->Get(title + "ArcHeight", 0);
+		AllowFallingDestroy = reader->Get(title + "AllowFallingDestroy", AllowFallingDestroy);
+		FallingDestroyHeight = reader->Get(title + "FallingDestroyHeight", FallingDestroyHeight);
 
 		// --- 速度 ---
 		InitialSpeed = reader->Get(title + "InitialSpeed", -1);
@@ -160,7 +163,7 @@ public:
 		Acceleration = reader->Get(title + "Acceleration", Acceleration);
 
 		Enable = !MoveTo.IsEmpty() || !TargetFLH.IsEmpty() || Force || Freeze
-			|| (CircleRadius > 0) || (CircleSpeed > 0) || (CircleAnglePerFrame > 0.0);
+			|| (CircleRadius > 0) || (CircleSpeed > 0) || (CircleAnglePerStep > 0.0);
 	}
 
 private:
@@ -194,13 +197,13 @@ private:
 
 			.Process(this->MoveTo)
 			.Process(this->GrowRate)
-			.Process(this->AnglePerFrame)
+			.Process(this->AnglePerStep)
 			.Process(this->CircleRadius)
 			.Process(this->CircleSpeed)
 			.Process(this->CircleSpeedAcceleration)
 			.Process(this->CircleMaxSpeed)
 			.Process(this->CircleMinSpeed)
-			.Process(this->CircleAnglePerFrame)
+			.Process(this->CircleAnglePerStep)
 			.Process(this->CircleAngleAcceleration)
 			.Process(this->CircleMaxAngle)
 			.Process(this->CircleMinAngle)
@@ -218,6 +221,9 @@ private:
 			.Process(this->TargetOffsetHMin)
 			.Process(this->TargetOffsetHMax)
 			.Process(this->ReachTarget)
+			.Process(this->ArcHeight)
+			.Process(this->AllowFallingDestroy)
+			.Process(this->FallingDestroyHeight)
 
 			.Process(this->InitialSpeed)
 			.Process(this->MaxSpeed)

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -199,6 +199,8 @@ VectorResult VectorEffect::GetVectorResult()
 
 	// Force 必须在闸门之前设，确保非运动帧也走 SetLocation（Freeze 等效）
 	result.Force = Data->Force;
+	result.AllowFallingDestroy = Data->AllowFallingDestroy;
+	result.FallingDestroyHeight = Data->FallingDestroyHeight;
 
 	// ========================================================================
 	// Freeze
@@ -305,7 +307,7 @@ VectorResult VectorEffect::GetVectorResult()
 	// ========================================================================
 	// 模式 C: Circle（独立圆周，圆心=Origin，三选二参数）
 	// ========================================================================
-	bool hasCircle = Data->CircleRadius > 0 || Data->CircleSpeed > 0 || Data->CircleAnglePerFrame > 0.0;
+	bool hasCircle = Data->CircleRadius > 0 || Data->CircleSpeed > 0 || Data->CircleAnglePerStep > 0.0;
 	if (hasCircle)
 	{
 		// 三选二：缺半径用当前XY距离，缺速度用半径×角速度，缺角速度用速度/半径
@@ -328,7 +330,7 @@ VectorResult VectorEffect::GetVectorResult()
 
 		// 角速度动态：首帧初始化，每帧叠加加速度
 		if (_elapsedFrames == 0)
-			_currentCircleAngle = Data->CircleAnglePerFrame;
+			_currentCircleAngle = Data->CircleAnglePerStep;
 		_currentCircleAngle += Data->CircleAngleAcceleration;
 		if (Data->CircleMaxAngle != 0.0 && _currentCircleAngle > Data->CircleMaxAngle)
 			_currentCircleAngle = Data->CircleMaxAngle;
@@ -401,11 +403,11 @@ VectorResult VectorEffect::GetVectorResult()
 	if (!Data->MoveTo.IsEmpty())
 	{
 		double moveFacing;
-		if (Data->AnglePerFrame != 0.0)
+		if (Data->AnglePerStep != 0.0)
 		{
 			if (_elapsedFrames == 0)
 				_currentAngle = 0.0;
-			_currentAngle += Data->AnglePerFrame;
+			_currentAngle += Data->AnglePerStep;
 			moveFacing = effectiveFacing + DegToRad(_currentAngle);
 		}
 		else if (pTechno)
@@ -430,12 +432,6 @@ VectorResult VectorEffect::GetVectorResult()
 	// ========================================================================
 	// 以下为 TargetFLH 相关模式
 	// ========================================================================
-	bool hasTarget = Data->TargetFLH.X != 0 || Data->TargetFLH.Y != 0 || Data->TargetFLH.Z != 0;
-	if (!hasTarget)
-	{
-		AdvanceFrame();
-		return result;
-	}
 
 	// --- 目标世界坐标 ---
 	CoordStruct frameTargetFlh;
@@ -477,6 +473,19 @@ VectorResult VectorEffect::GetVectorResult()
 			resultDisp.X = static_cast<int>(dirVec.X / dirLen * adjustedSpeed);
 			resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * adjustedSpeed);
 			resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * adjustedSpeed);
+
+			// 抛物线弧高修正 Z
+			if (Data->ArcHeight != 0)
+			{
+				double t = static_cast<double>(_elapsedFrames) / _totalDuration;
+				double tNext = static_cast<double>(_elapsedFrames + 1) / _totalDuration;
+				double z0 = _initialLocation.Z;
+				double z1 = frameTarget.Z;
+				double h = Data->ArcHeight;
+				double zCur = z0 + (z1 - z0) * t + 4.0 * h * t * (1.0 - t);
+				double zNext = z0 + (z1 - z0) * tNext + 4.0 * h * tNext * (1.0 - tNext);
+				resultDisp.Z = static_cast<int>(zNext - zCur);
+			}
 		}
 	}
 	// ========================================================================

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -10,6 +10,10 @@
 #include <Ext/EffectType/AttachEffectScript.h>
 #include <Ext/BulletType/BulletStatus.h>
 
+
+// Vector: Freeze / Circle / MoveTo / Speed / ReachTarget
+// 基于 V1 VectorEffect.cpp 精简
+
 void VectorEffect::OnStart()
 {
 	if (pTechno && pTechno->WhatAmI() == AbstractType::Building)
@@ -18,387 +22,491 @@ void VectorEffect::OnStart()
 		return;
 	}
 
-	_initialLocation = pObject->GetCoords();
+	_active = true;
 	_elapsedFrames = 0;
 	_moveFrame = 0;
+	_currentAngle = 0.0;
+	_prevCirclePos = pObject->GetCoords();
+	_effectiveTimeStep = Data->TimeStep;
 
-	if (Data->TargetRandF.X != 0 || Data->TargetRandF.Y != 0
-		|| Data->TargetRandL.X != 0 || Data->TargetRandL.Y != 0
-		|| Data->TargetRandH.X != 0 || Data->TargetRandH.Y != 0)
+	_initialLocation = pObject->GetCoords();
+	_totalDuration = AE->GetDuration();
+
+	_randomTargetOffset.X = Random::RandomRanged(Data->TargetOffsetFMin, Data->TargetOffsetFMax);
+	_randomTargetOffset.Y = Random::RandomRanged(Data->TargetOffsetLMin, Data->TargetOffsetLMax);
+	_randomTargetOffset.Z = Random::RandomRanged(Data->TargetOffsetHMin, Data->TargetOffsetHMax);
+
+	// --- 初始速度 ---
+	_currentSpeed = 0.0;
+	if (Data->InitialSpeed >= 0)
 	{
-		_randomTargetOffset.X = Random::RandomRanged(Data->TargetRandF.X, Data->TargetRandF.Y);
-		_randomTargetOffset.Y = Random::RandomRanged(Data->TargetRandL.X, Data->TargetRandL.Y);
-		_randomTargetOffset.Z = Random::RandomRanged(Data->TargetRandH.X, Data->TargetRandH.Y);
+		_currentSpeed = static_cast<double>(Data->InitialSpeed);
 	}
-
-	if (pTechno)
+	else if (pTechno)
 	{
-		if (Data->StartSpeed > 0)
-		{
-			_currentSpeed = Data->StartSpeed;
-		}
+		TechnoTypeClass* pType = pTechno->GetTechnoType();
+		if (GetLocoType(pTechno) == LocoType::Jumpjet)
+			_currentSpeed = pType->JumpjetSpeed;
 		else
-		{
-			TechnoTypeClass* pType = pTechno->GetTechnoType();
-			if (GetLocoType(pTechno) == LocoType::Jumpjet)
-			{
-				_currentSpeed = pType->JumpjetSpeed;
-			}
-			else
-			{
-				_currentSpeed = pType->Speed;
-			}
-			if (_currentSpeed <= 0)
-			{
-				_currentSpeed = pType->Speed;
-			}
-		}
+			_currentSpeed = pType->Speed;
 	}
 	else if (pBullet)
 	{
-		if (Data->StartSpeed > 0)
-		{
-			_currentSpeed = Data->StartSpeed;
-		}
-		else
-		{
-			_currentSpeed = pBullet->Speed;
-		}
+		_currentSpeed = pBullet->Speed;
 	}
 
-	// 保存初始 Origin 位置（NoUpdate 模式用）
-	if (Data->OriginNoUpdate)
+	// --- Origin 初始化 ---
+	switch (Data->Origin)
 	{
-		switch (Data->Origin)
+	case VectorData::VectorOrigin::Target:
+		if (Data->OriginNoUpdate)
 		{
-		case VectorData::VectorOrigin::Target:
 			if (pTechno && pTechno->Target)
 				_initialOriginPos = pTechno->Target->GetCoords();
 			else if (pBullet)
 				_initialOriginPos = pBullet->TargetCoords;
-			break;
-		case VectorData::VectorOrigin::Launcher:
+		}
+		break;
+
+	case VectorData::VectorOrigin::Launcher:
+		if (Data->OriginNoUpdate)
+		{
 			if (pBullet && pBullet->Owner)
 				_initialOriginPos = pBullet->Owner->GetCoords();
 			else if (pTechno)
 				_initialOriginPos = pTechno->GetCoords();
-			break;
-		case VectorData::VectorOrigin::Source:
+		}
+		if (pBullet)
+			_pLauncher = pBullet->Owner;
+		else if (pTechno)
+			_pLauncher = pTechno;
+		break;
+
+	case VectorData::VectorOrigin::Source:
+		if (Data->OriginNoUpdate)
+		{
 			if (AE && AE->pSource)
 				_initialOriginPos = AE->pSource->GetCoords();
-			break;
-		default:
-			break;
 		}
-	}
-
-	switch (Data->Origin)
-	{
-	case VectorData::VectorOrigin::Target:
-		if (pTechno && pTechno->Target)
-		{
-			_initialTarget = pTechno->Target->GetCoords();
-		}
-		else if (pBullet)
-		{
-			_initialTarget = pBullet->TargetCoords;
-		}
-		break;
-	case VectorData::VectorOrigin::Launcher:
-		if (pBullet)
-		{
-			_pLauncher = pBullet->Owner;
-		}
-		else if (pTechno)
-		{
-			_pLauncher = pTechno;
-		}
-		break;
-	case VectorData::VectorOrigin::Source:
 		if (AE && AE->pSource)
-		{
 			_pSource = AE->pSource;
-		}
 		break;
+
 	case VectorData::VectorOrigin::FLH:
 		if (pTechno)
 		{
 			CoordStruct unitPos = pTechno->GetCoords();
-			DirStruct unitFacing = pTechno->PrimaryFacing.Current();
+			DirStruct unitFacing = pTechno->TurretFacing().Current();
+			_initialOriginPos = GetFLHAbsoluteCoords(unitPos, Data->OriginFLH, unitFacing);
+		}
+		else if (pBullet && pBullet->Owner)
+		{
+			CoordStruct unitPos = pBullet->Owner->GetCoords();
+			DirStruct unitFacing = pBullet->Owner->TurretFacing().Current();
 			_initialOriginPos = GetFLHAbsoluteCoords(unitPos, Data->OriginFLH, unitFacing);
 		}
 		break;
-	default:
+	}
+
+	// --- 锁定 FLH 旋转朝向（OnStart 时固定，避免炮塔追踪导致目标漂移） ---
+	switch (Data->Origin)
+	{
+	case VectorData::VectorOrigin::Launcher:
+	{
+		// F 轴 = Launcher → 抛射体/单位 连线方向，Launcher 为原点
+		if (pBullet && _pLauncher)
+		{
+			CoordStruct launcherPos = _pLauncher->GetCoords();
+			CoordStruct objPos = pBullet->GetCoords();
+			_facingRad = std::atan2(objPos.Y - launcherPos.Y, objPos.X - launcherPos.X);
+		}
+		else if (pTechno && _pLauncher)
+		{
+			CoordStruct launcherPos = _pLauncher->GetCoords();
+			CoordStruct objPos = pTechno->GetCoords();
+			_facingRad = std::atan2(objPos.Y - launcherPos.Y, objPos.X - launcherPos.X);
+		}
 		break;
 	}
 
-#ifdef DEBUG_AE
-	Debug::Log("Vector: [%s] Start, Pos=(%d,%d,%d), Speed=%d\n",
-		pObject->GetType()->ID, _initialLocation.X, _initialLocation.Y, _initialLocation.Z, _currentSpeed);
-#endif
+	case VectorData::VectorOrigin::Target:
+	{
+		// F 轴 = Target → 抛射体/单位 连线方向，Target 为原点
+		if (pTechno && pTechno->Target)
+		{
+			CoordStruct targetPos = pTechno->Target->GetCoords();
+			CoordStruct selfPos = pTechno->GetCoords();
+			_facingRad = std::atan2(selfPos.Y - targetPos.Y, selfPos.X - targetPos.X);
+		}
+		else if (pBullet)
+		{
+			CoordStruct bulletPos = pBullet->GetCoords();
+			CoordStruct targetPos = pBullet->TargetCoords;
+			_facingRad = std::atan2(bulletPos.Y - targetPos.Y, bulletPos.X - targetPos.X);
+		}
+		break;
+	}
+
+	case VectorData::VectorOrigin::Source:
+	{
+		// F 轴 = Source → 抛射体/单位当前位置（仅 XY，不纳入 Z 以避免倾斜坐标系）
+		if (pBullet && AE && AE->pSource)
+		{
+			CoordStruct srcPos = AE->pSource->GetCoords();
+			CoordStruct objPos = pBullet->GetCoords();
+			_facingRad = std::atan2(objPos.Y - srcPos.Y, objPos.X - srcPos.X);
+		}
+		else if (pTechno && AE && AE->pSource)
+		{
+			CoordStruct srcPos = AE->pSource->GetCoords();
+			CoordStruct objPos = pTechno->GetCoords();
+			_facingRad = std::atan2(objPos.Y - srcPos.Y, objPos.X - srcPos.X);
+		}
+		break;
+	}
+
+	default:
+	{
+		DirStruct facing;
+		if (pTechno)
+			facing = pTechno->TurretFacing().Current();
+		else if (pBullet && pBullet->Owner)
+			facing = pBullet->Owner->TurretFacing().Current();
+		_facingRad = facing.GetRadian();
+		break;
+	}
+	}
+}
+
+static double DegToRad(double deg) { return deg * M_PI / 180.0; }
+static double RadToDeg(double rad) { return rad * 180.0 / M_PI; }
+
+// FLH → 世界坐标旋转（Y 轴镜像，使用 OnStart 时锁定的朝向）
+static CoordStruct RotateFLH(const CoordStruct& flh, double facingRad)
+{
+	double cosA = std::cos(facingRad);
+	double sinA = std::sin(facingRad);
+	return CoordStruct{
+		static_cast<int>(flh.X * cosA - flh.Y * sinA),
+		static_cast<int>(-(flh.X * sinA + flh.Y * cosA)),
+		flh.Z
+	};
 }
 
 VectorResult VectorEffect::GetVectorResult()
 {
 	VectorResult result;
+
+	// Force 必须在闸门之前设，确保非运动帧也走 SetLocation（Freeze 等效）
+	result.Force = Data->Force;
+
+	// ========================================================================
+	// Freeze
+	// ========================================================================
 	if (Data->Freeze)
 	{
 		result.Freeze = true;
-		// 取第一个 Freeze VectorEffect 的初始位置作为冻结锚点
 		if (result.FrozenPos.IsEmpty())
-		{
 			result.FrozenPos = _initialLocation;
-		}
+		return result;
 	}
-	else
+
+	// ========================================================================
+	// TimeStep 闸门
+	// ========================================================================
+	if (!ShouldMoveThisFrame())
 	{
-		CoordStruct currentPos = pObject->GetCoords();
-		CoordStruct originPos = currentPos; // 默认原点为当前位置，后续根据 Origin 类型调整
+		_moveFrame++;
+		return result;
+	}
+
+	CoordStruct currentPos = pObject->GetCoords();
+
+	// ========================================================================
+	// 动态 F 轴：非 NoUpdate 时每帧根据当前坐标重新计算 FLH 朝向
+	// ========================================================================
+	double effectiveFacing = _facingRad;
+	if (!Data->OriginNoUpdate)
+	{
 		switch (Data->Origin)
 		{
-		case VectorData::VectorOrigin::World:
-		case VectorData::VectorOrigin::Realtime:
+		case VectorData::VectorOrigin::Source:
+			if (_pSource && !IsDeadOrInvisible(_pSource))
+			{
+				CoordStruct srcPos = _pSource->GetCoords();
+				effectiveFacing = std::atan2(currentPos.Y - srcPos.Y, currentPos.X - srcPos.X);
+			}
 			break;
 		case VectorData::VectorOrigin::Target:
-			originPos = Data->OriginNoUpdate ? _initialOriginPos : _initialTarget;
+			if (pTechno && pTechno->Target)
+			{
+				CoordStruct targetPos = pTechno->Target->GetCoords();
+				effectiveFacing = std::atan2(currentPos.Y - targetPos.Y, currentPos.X - targetPos.X);
+			}
+			else if (pBullet)
+			{
+				CoordStruct targetPos = pBullet->TargetCoords;
+				effectiveFacing = std::atan2(currentPos.Y - targetPos.Y, currentPos.X - targetPos.X);
+			}
 			break;
+
 		case VectorData::VectorOrigin::Launcher:
-			if (Data->OriginNoUpdate)
-				originPos = _initialOriginPos;
-			else if (_pLauncher && !IsDeadOrInvisible(_pLauncher))
-				originPos = _pLauncher->GetCoords();
-			break;
-		case VectorData::VectorOrigin::Source:
-			if (Data->OriginNoUpdate)
-				originPos = _initialOriginPos;
-			else if (_pSource && !IsDeadOrInvisible(_pSource))
-				originPos = _pSource->GetCoords();
-			break;
-		case VectorData::VectorOrigin::Self:
-			originPos = _initialLocation;
-			break;
-		case VectorData::VectorOrigin::FLH:
-			originPos = _initialOriginPos;
-			break;
-		default:
+			if (_pLauncher && !IsDeadOrInvisible(_pLauncher))
+			{
+				CoordStruct launcherPos = _pLauncher->GetCoords();
+				effectiveFacing = std::atan2(currentPos.Y - launcherPos.Y, currentPos.X - launcherPos.X);
+			}
 			break;
 		}
+	}
 
-		CoordStruct frameTargetFlh;
-		frameTargetFlh.X = Data->TargetFLH.X + _randomTargetOffset.X;
-		frameTargetFlh.Y = Data->TargetFLH.Y + _randomTargetOffset.Y;
-		frameTargetFlh.Z = Data->TargetFLH.Z + _randomTargetOffset.Z;
+	// ========================================================================
+	// Origin 坐标
+	// ========================================================================
+	CoordStruct originPos = currentPos;
 
-		// TargetFLH → 世界坐标（与 MoveTo 一致）
-		CoordStruct frameTargetDisp;
-		if (Data->Origin == VectorData::VectorOrigin::World)
+	switch (Data->Origin)
+	{
+	case VectorData::VectorOrigin::Target:
+		if (Data->OriginNoUpdate)
 		{
-			frameTargetDisp = frameTargetFlh;
+			originPos = _initialOriginPos;
+		}
+		else if (pTechno && pTechno->Target)
+		{
+			originPos = pTechno->Target->GetCoords();
 		}
 		else if (pBullet)
 		{
-			double vx = pBullet->Velocity.X;
-			double vy = pBullet->Velocity.Y;
-			double len = std::sqrt(vx * vx + vy * vy);
-			if (len > 1e-6)
-			{
-				double fwdX = vx / len;
-				double fwdY = vy / len;
-				frameTargetDisp.X = static_cast<int>(frameTargetFlh.X * fwdX - frameTargetFlh.Y * fwdY);
-				frameTargetDisp.Y = static_cast<int>(-(frameTargetFlh.X * fwdY + frameTargetFlh.Y * fwdX));
-				frameTargetDisp.Z = frameTargetFlh.Z;
-			}
+			// 优先取抛射体自身的实时目标（寻的弹会更新）
+			if (pBullet->Target)
+				originPos = pBullet->Target->GetCoords();
+			// 其次取发射者的当前目标
+			else if (pBullet->Owner && pBullet->Owner->Target)
+				originPos = pBullet->Owner->Target->GetCoords();
+			// 最后回退到自身位置（避免圆心锁死在初始坐标）
 			else
-			{
-				frameTargetDisp = frameTargetFlh;
-			}
+				originPos = currentPos;
+		}
+		break;
+	case VectorData::VectorOrigin::Launcher:
+		originPos = Data->OriginNoUpdate ? _initialOriginPos :
+			(_pLauncher && !IsDeadOrInvisible(_pLauncher) ? _pLauncher->GetCoords() : currentPos);
+		break;
+	case VectorData::VectorOrigin::Source:
+		originPos = Data->OriginNoUpdate ? _initialOriginPos :
+			(_pSource && !IsDeadOrInvisible(_pSource) ? _pSource->GetCoords() : currentPos);
+		break;
+	case VectorData::VectorOrigin::FLH:
+		originPos = _initialOriginPos;
+		break;
+	}
+
+	// ========================================================================
+	// 模式 C: Circle（独立圆周，圆心=Origin，三选二参数）
+	// ========================================================================
+	bool hasCircle = Data->CircleRadius > 0 || Data->CircleSpeed > 0 || Data->CircleAnglePerFrame > 0.0;
+	if (hasCircle)
+	{
+		// 三选二：缺半径用当前XY距离，缺速度用半径×角速度，缺角速度用速度/半径
+		double calcRadius = static_cast<double>(Data->CircleRadius);
+		if (calcRadius <= 0.0)
+		{
+			double tdx = currentPos.X - originPos.X;
+			double tdy = currentPos.Y - originPos.Y;
+			calcRadius = std::sqrt(tdx * tdx + tdy * tdy);
+		}
+
+		// 动态线速：首帧初始化，每帧叠加加速度
+		if (_elapsedFrames == 0)
+			_currentCircleSpeed = static_cast<double>(Data->CircleSpeed);
+		_currentCircleSpeed += Data->CircleSpeedAcceleration;
+		if (Data->CircleMaxSpeed != 0 && _currentCircleSpeed > Data->CircleMaxSpeed)
+			_currentCircleSpeed = static_cast<double>(Data->CircleMaxSpeed);
+		if (Data->CircleMinSpeed != 0 && _currentCircleSpeed < Data->CircleMinSpeed)
+			_currentCircleSpeed = static_cast<double>(Data->CircleMinSpeed);
+
+		// 角速度动态：首帧初始化，每帧叠加加速度
+		if (_elapsedFrames == 0)
+			_currentCircleAngle = Data->CircleAnglePerFrame;
+		_currentCircleAngle += Data->CircleAngleAcceleration;
+		if (Data->CircleMaxAngle != 0.0 && _currentCircleAngle > Data->CircleMaxAngle)
+			_currentCircleAngle = Data->CircleMaxAngle;
+		if (Data->CircleMinAngle != 0.0 && _currentCircleAngle < Data->CircleMinAngle)
+			_currentCircleAngle = Data->CircleMinAngle;
+
+		double speed = _currentCircleSpeed;
+		double angleStep = _currentCircleAngle;
+
+		if (speed <= 0.0 && angleStep > 0.0)
+			speed = calcRadius * DegToRad(angleStep);
+		else if (angleStep <= 0.0 && speed > 0.0)
+			angleStep = RadToDeg(speed / calcRadius);
+
+		// 旋转当前方向向量并按目标半径缩放
+		double dx = static_cast<double>(currentPos.X - originPos.X);
+		double dy = static_cast<double>(currentPos.Y - originPos.Y);
+		double currentDist = std::sqrt(dx * dx + dy * dy);
+		if (currentDist < 1.0) currentDist = 1.0;
+
+		// 动态半径：首帧初始化，每帧叠加增长率
+		if (_elapsedFrames == 0)
+		{
+			_currentCircleRadius = static_cast<double>(Data->CircleRadius);
+			if (_currentCircleRadius <= 0.0)
+				_currentCircleRadius = currentDist;
+		}
+		_currentCircleRadius += Data->CircleRadiusGrow;
+
+		double targetRadius = _currentCircleRadius;
+		// 钳位
+		if (Data->CircleMaxRadius > 0 && targetRadius > Data->CircleMaxRadius)
+			targetRadius = static_cast<double>(Data->CircleMaxRadius);
+		if (Data->CircleMinRadius > 0 && targetRadius < Data->CircleMinRadius)
+			targetRadius = static_cast<double>(Data->CircleMinRadius);
+
+		double rad = DegToRad(angleStep);
+		double cosA = std::cos(rad), sinA = std::sin(rad);
+
+		// 当前方向归一化 × 目标半径 → 旋转 → 新世界坐标
+		double ndx = (dx / currentDist * targetRadius);
+		double ndy = (dy / currentDist * targetRadius);
+		double rx = ndx * cosA - ndy * sinA;
+		double ry = ndx * sinA + ndy * cosA;
+
+		result.MoveDisp.X = originPos.X + static_cast<int>(rx) - currentPos.X;
+		result.MoveDisp.Y = originPos.Y + static_cast<int>(ry) - currentPos.Y;
+		result.MoveDisp.Z = 0;
+		result.Force = true;
+
+		// 到达边界时结束 AE
+		if (Data->CircleEndOnMaxRadius && Data->CircleMaxRadius > 0
+			&& _currentCircleRadius >= Data->CircleMaxRadius)
+		{
+			Deactivate();
+		}
+		if (Data->CircleEndOnMinRadius && Data->CircleMinRadius > 0
+			&& _currentCircleRadius <= Data->CircleMinRadius)
+		{
+			Deactivate();
+		}
+
+		AdvanceFrame();
+		return result;
+	}
+
+	// ========================================================================
+	// 模式 1: MoveTo（纯 FLH 位移 + GrowRate，每帧动态 FLH 朝向）
+	// ========================================================================
+	if (!Data->MoveTo.IsEmpty())
+	{
+		double moveFacing;
+		if (Data->AnglePerFrame != 0.0)
+		{
+			if (_elapsedFrames == 0)
+				_currentAngle = 0.0;
+			_currentAngle += Data->AnglePerFrame;
+			moveFacing = effectiveFacing + DegToRad(_currentAngle);
 		}
 		else if (pTechno)
-		{
-			DirStruct facing = pTechno->PrimaryFacing.Current();
-			double rad = facing.GetRadian();
-			double cosA = std::cos(rad);
-			double sinA = std::sin(rad);
-			frameTargetDisp.X = static_cast<int>(frameTargetFlh.X * cosA - frameTargetFlh.Y * sinA);
-			frameTargetDisp.Y = static_cast<int>(-(frameTargetFlh.X * sinA + frameTargetFlh.Y * cosA));
-			frameTargetDisp.Z = frameTargetFlh.Z;
-		}
+			moveFacing = pTechno->TurretFacing().Current().GetRadian();
+		else if (pBullet)
+			moveFacing = std::atan2(pBullet->Velocity.X, pBullet->Velocity.Y);
 		else
+			moveFacing = _facingRad;
+
+		CoordStruct moveFlh;
+		moveFlh.X = Data->MoveTo.X + static_cast<int>(Data->GrowRate.X * _elapsedFrames);
+		moveFlh.Y = Data->MoveTo.Y + static_cast<int>(Data->GrowRate.Y * _elapsedFrames);
+		moveFlh.Z = Data->MoveTo.Z + static_cast<int>(Data->GrowRate.Z * _elapsedFrames);
+
+		result.MoveDisp = RotateFLH(moveFlh, moveFacing);
+		result.Force = true;
+
+		AdvanceFrame();
+		return result;
+	}
+
+	// ========================================================================
+	// 以下为 TargetFLH 相关模式
+	// ========================================================================
+	bool hasTarget = Data->TargetFLH.X != 0 || Data->TargetFLH.Y != 0 || Data->TargetFLH.Z != 0;
+	if (!hasTarget)
+	{
+		AdvanceFrame();
+		return result;
+	}
+
+	// --- 目标世界坐标 ---
+	CoordStruct frameTargetFlh;
+	frameTargetFlh.X = Data->TargetFLH.X + _randomTargetOffset.X;
+	frameTargetFlh.Y = Data->TargetFLH.Y + _randomTargetOffset.Y;
+	frameTargetFlh.Z = Data->TargetFLH.Z + _randomTargetOffset.Z;
+
+	CoordStruct frameTargetDisp = RotateFLH(frameTargetFlh, effectiveFacing);
+	CoordStruct frameTarget;
+	frameTarget.X = originPos.X + frameTargetDisp.X;
+	frameTarget.Y = originPos.Y + frameTargetDisp.Y;
+	frameTarget.Z = originPos.Z + frameTargetDisp.Z;
+
+	// --- 方向向量 ---
+	CoordStruct dirVec;
+	dirVec.X = frameTarget.X - currentPos.X;
+	dirVec.Y = frameTarget.Y - currentPos.Y;
+	dirVec.Z = frameTarget.Z - currentPos.Z;
+	double dirLen = std::sqrt(static_cast<double>(dirVec.X * dirVec.X + dirVec.Y * dirVec.Y + dirVec.Z * dirVec.Z));
+
+	CoordStruct resultDisp{ 0, 0, 0 };
+
+	// ========================================================================
+	// 模式 2: ReachTarget（剩余帧数强制到达，每帧重算以支持目标移动）
+	// ========================================================================
+	if (Data->ReachTarget && _totalDuration > 0)
+	{
+		int remainingFrames = _totalDuration - _elapsedFrames;
+		if (remainingFrames <= 0)
 		{
-			frameTargetDisp = frameTargetFlh;
+			// 已超时，直接到达目标
+			resultDisp.X = frameTarget.X - currentPos.X;
+			resultDisp.Y = frameTarget.Y - currentPos.Y;
+			resultDisp.Z = frameTarget.Z - currentPos.Z;
 		}
+		else if (dirLen > 1e-6)
+		{
+			double adjustedSpeed = dirLen / remainingFrames;
+			resultDisp.X = static_cast<int>(dirVec.X / dirLen * adjustedSpeed);
+			resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * adjustedSpeed);
+			resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * adjustedSpeed);
+		}
+	}
+	// ========================================================================
+	// 模式 3: Speed（直线追踪 + 加速度）
+	// ========================================================================
+	else if (dirLen > 1e-6)
+	{
+		double speed = _currentSpeed;
 
-		CoordStruct frameTarget;
-		frameTarget.X = originPos.X + frameTargetDisp.X;
-		frameTarget.Y = originPos.Y + frameTargetDisp.Y;
-		frameTarget.Z = originPos.Z + frameTargetDisp.Z;
-
-		bool hasTarget = Data->TargetFLH.X != 0 || Data->TargetFLH.Y != 0 || Data->TargetFLH.Z != 0;
-
-		// --- 速度计算（加速度 + 振荡）---
-		int speed = _currentSpeed;
+		// 加速度
 		if (Data->Acceleration != 0)
 		{
 			speed += Data->Acceleration * _elapsedFrames;
 		}
-		if (Data->EndSpeed >= 0)
-		{
-			speed = std::clamp(speed, std::min(_currentSpeed, Data->EndSpeed), std::max(_currentSpeed, Data->EndSpeed));
-		}
-		if (Data->SpeedOscillation != 0 && Data->SpeedOscFreq != 0)
-		{
-			double phase = (_elapsedFrames * Data->SpeedOscFreq + Data->SpeedOscPhase) * M_PI / 180.0;
-			speed += static_cast<int>(Data->SpeedOscillation * std::sin(phase));
-		}
-		if (speed <= 0) speed = 1;
 
-		// --- MoveTo 振荡 ---
-		CoordStruct growOsc{};
-		if (Data->GrowOscFreqX != 0)
-		{
-			double phaseX = (_elapsedFrames * Data->GrowOscFreqX + Data->GrowOscPhaseX) * M_PI / 180.0;
-			growOsc.X = static_cast<int>(Data->GrowOscillationX * std::sin(phaseX));
-		}
-		if (Data->GrowOscFreqY != 0)
-		{
-			double phaseY = (_elapsedFrames * Data->GrowOscFreqY + Data->GrowOscPhaseY) * M_PI / 180.0;
-			growOsc.Y = static_cast<int>(Data->GrowOscillationY * std::sin(phaseY));
-		}
-		if (Data->GrowOscFreqZ != 0)
-		{
-			double phaseZ = (_elapsedFrames * Data->GrowOscFreqZ + Data->GrowOscPhaseZ) * M_PI / 180.0;
-			growOsc.Z = static_cast<int>(Data->GrowOscillationZ * std::sin(phaseZ));
-		}
+		// 钳位
+		if (Data->MinSpeed >= 0 && speed < Data->MinSpeed)
+			speed = static_cast<double>(Data->MinSpeed);
+		if (Data->MaxSpeed >= 0 && speed > Data->MaxSpeed)
+			speed = static_cast<double>(Data->MaxSpeed);
 
-		// --- MoveTo FLH 位移 ---
-		CoordStruct moveFlh{};
-		moveFlh.X = Data->MoveTo.X + static_cast<int>(Data->GrowRate.X * _moveFrame) + growOsc.X;
-		moveFlh.Y = Data->MoveTo.Y + static_cast<int>(Data->GrowRate.Y * _moveFrame) + growOsc.Y;
-		moveFlh.Z = Data->MoveTo.Z + static_cast<int>(Data->GrowRate.Z * _moveFrame) + growOsc.Z;
+		if (speed <= 0.0) speed = 1.0;
 
-		// FLH → 世界坐标（与游戏引擎 GetFLHAbsoluteCoords 一致，Y 轴镜像）
-		CoordStruct moveDisp;
-		if (Data->Origin == VectorData::VectorOrigin::World)
-		{
-			// World 模式下 MoveTo 已是世界坐标，不做旋转
-			moveDisp = moveFlh;
-		}
-		else if (pBullet)
-		{
-			double vx = pBullet->Velocity.X;
-			double vy = pBullet->Velocity.Y;
-			double len = std::sqrt(vx * vx + vy * vy);
-			if (len > 1e-6)
-			{
-				double fwdX = vx / len;
-				double fwdY = vy / len;
-				moveDisp.X = static_cast<int>(moveFlh.X * fwdX - moveFlh.Y * fwdY);
-				moveDisp.Y = static_cast<int>(-(moveFlh.X * fwdY + moveFlh.Y * fwdX));
-				moveDisp.Z = moveFlh.Z;
-			}
-			else
-			{
-				moveDisp = moveFlh;
-			}
-		}
-		else if (pTechno)
-		{
-			DirStruct facing = pTechno->PrimaryFacing.Current();
-			double rad = facing.GetRadian();
-			double cosA = std::cos(rad);
-			double sinA = std::sin(rad);
-			moveDisp.X = static_cast<int>(moveFlh.X * cosA - moveFlh.Y * sinA);
-			moveDisp.Y = static_cast<int>(-(moveFlh.X * sinA + moveFlh.Y * cosA));
-			moveDisp.Z = moveFlh.Z;
-		}
-		else
-		{
-			moveDisp = moveFlh;
-		}
-
-		// --- 波浪运动（垂直于运动方向的正弦偏移）---
-		CoordStruct waveDisp{};
-		if (Data->WaveAmplitude.X != 0 || Data->WaveAmplitude.Y != 0 || Data->WaveAmplitude.Z != 0)
-		{
-			double freqX = Data->WaveFrequency.X + Data->WaveFreqAcceleration.X * _elapsedFrames;
-			double freqY = Data->WaveFrequency.Y + Data->WaveFreqAcceleration.Y * _elapsedFrames;
-			double freqZ = Data->WaveFrequency.Z + Data->WaveFreqAcceleration.Z * _elapsedFrames;
-
-			double ampX = Data->WaveAmplitude.X;
-			double ampY = Data->WaveAmplitude.Y;
-			double ampZ = Data->WaveAmplitude.Z;
-			if (Data->WaveAmpOscillation != 0 && Data->WaveAmpOscFreq != 0)
-			{
-				double ampPhase = (_elapsedFrames * Data->WaveAmpOscFreq + Data->WaveAmpOscPhase) * M_PI / 180.0;
-				double ampOsc = Data->WaveAmpOscillation * std::sin(ampPhase);
-				ampX += ampOsc;
-				ampY += ampOsc;
-				ampZ += ampOsc;
-			}
-
-			waveDisp.X = static_cast<int>(ampX * std::sin((freqX * _elapsedFrames + Data->WavePhase.X) * M_PI / 180.0));
-			waveDisp.Y = static_cast<int>(ampY * std::sin((freqY * _elapsedFrames + Data->WavePhase.Y) * M_PI / 180.0));
-			waveDisp.Z = static_cast<int>(ampZ * std::sin((freqZ * _elapsedFrames + Data->WavePhase.Z) * M_PI / 180.0));
-		}
-
-		// --- 圆周旋转 ---
-		CoordStruct rotateDisp{};
-		if (Data->AnglePerFrame != 0 && Data->Radius != 0)
-		{
-			CoordStruct axis = GetRotateAxis(Data->RotateAxis);
-			double angle = Data->AnglePerFrame * _elapsedFrames;
-			CoordStruct offset = { Data->Radius, 0, 0 };
-			rotateDisp = RodriguesRotate(offset, axis, angle);
-			// 减去第一帧的偏移，使旋转从当前位置开始
-			CoordStruct firstFrame = RodriguesRotate(offset, axis, 0);
-			rotateDisp.X -= firstFrame.X;
-			rotateDisp.Y -= firstFrame.Y;
-			rotateDisp.Z -= firstFrame.Z;
-		}
-
-		// --- 朝目标飞行 + MoveTo 偏移 + 波浪 + 旋转 ---
-		CoordStruct nextPos;
-		if (hasTarget)
-		{
-			CoordStruct dirVec;
-			dirVec.X = frameTarget.X - currentPos.X;
-			dirVec.Y = frameTarget.Y - currentPos.Y;
-			dirVec.Z = frameTarget.Z - currentPos.Z;
-			double dirLen = std::sqrt(static_cast<double>(dirVec.X * dirVec.X + dirVec.Y * dirVec.Y + dirVec.Z * dirVec.Z));
-
-			// ReachTarget：到达目标后停止
-			if (Data->ReachTarget && dirLen <= speed)
-			{
-				nextPos = frameTarget;
-			}
-			else if (dirLen > 1e-6)
-			{
-				nextPos.X = currentPos.X + static_cast<int>(dirVec.X / dirLen * speed) + moveDisp.X + waveDisp.X + rotateDisp.X;
-				nextPos.Y = currentPos.Y + static_cast<int>(dirVec.Y / dirLen * speed) + moveDisp.Y + waveDisp.Y + rotateDisp.Y;
-				nextPos.Z = currentPos.Z + static_cast<int>(dirVec.Z / dirLen * speed) + moveDisp.Z + waveDisp.Z + rotateDisp.Z;
-			}
-			else
-			{
-				nextPos.X = currentPos.X + moveDisp.X + waveDisp.X + rotateDisp.X;
-				nextPos.Y = currentPos.Y + moveDisp.Y + waveDisp.Y + rotateDisp.Y;
-				nextPos.Z = currentPos.Z + moveDisp.Z + waveDisp.Z + rotateDisp.Z;
-			}
-		}
-		else
-		{
-			nextPos.X = currentPos.X + moveDisp.X + waveDisp.X + rotateDisp.X;
-			nextPos.Y = currentPos.Y + moveDisp.Y + waveDisp.Y + rotateDisp.Y;
-			nextPos.Z = currentPos.Z + moveDisp.Z + waveDisp.Z + rotateDisp.Z;
-		}
-
-		// 合并偏移量
-		result.MoveDisp.X += nextPos.X - currentPos.X;
-		result.MoveDisp.Y += nextPos.Y - currentPos.Y;
-		result.MoveDisp.Z += nextPos.Z - currentPos.Z;
-
-		_elapsedFrames += Data->FrameStep;
-		_moveFrame++;
+		resultDisp.X = static_cast<int>(dirVec.X / dirLen * speed);
+		resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * speed);
+		resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * speed);
 	}
 
+	result.MoveDisp = resultDisp;
+
+	AdvanceFrame();
 	return result;
 }

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <string>
 #include <vector>
@@ -17,35 +17,67 @@ public:
 	{
 		EffectScript::Clean();
 
-		_initialLocation = {};
-		_initialTarget = {};
-		_initialOriginPos = {};
-		_randomTargetOffset = {};
-		_pLauncher = nullptr;
-		_pSource = nullptr;
-		_currentSpeed = 0;
+		_active = false;
 		_elapsedFrames = 0;
 		_moveFrame = 0;
+		_currentSpeed = 0.0;
+		_effectiveTimeStep = 1;
+		_initialLocation = {};
+		_initialOriginPos = {};
+		_pLauncher = nullptr;
+		_pTarget = nullptr;
+		_pSource = nullptr;
+		_totalDuration = 0;
+		_randomTargetOffset = {};
+		_facingRad = 0.0;
+		_currentAngle = 0.0;
+		_prevCirclePos = {};
+		_currentCircleRadius = 0.0;
+		_currentCircleSpeed = 0.0;
+		_currentCircleAngle = 0.0;
 	}
 
 	virtual void OnStart() override;
 
-	// 获取位移结果，包含位移向量和冻结状态等信息
 	VectorResult GetVectorResult();
+
+	// ========================================================================
+	// V2 设计文档 §5 状态变量
+	// ========================================================================
+
+	bool ShouldMoveThisFrame() const
+	{
+		return (_moveFrame % _effectiveTimeStep) == 0;
+	}
+
+	void AdvanceFrame()
+	{
+		_elapsedFrames++;
+		_moveFrame++;
+	}
 
 #pragma region Save/Load
 	template <typename T>
 	bool Serialize(T& stream) {
 		stream
-			.Process(this->_initialLocation)
-			.Process(this->_initialTarget)
-			.Process(this->_initialOriginPos)
-			.Process(this->_randomTargetOffset)
-			.Process(this->_pLauncher)
-			.Process(this->_pSource)
-			.Process(this->_currentSpeed)
+			.Process(this->_active)
 			.Process(this->_elapsedFrames)
-			.Process(this->_moveFrame);
+			.Process(this->_moveFrame)
+			.Process(this->_currentSpeed)
+			.Process(this->_effectiveTimeStep)
+			.Process(this->_initialLocation)
+			.Process(this->_initialOriginPos)
+			.Process(this->_pLauncher)
+			.Process(this->_pTarget)
+			.Process(this->_pSource)
+			.Process(this->_totalDuration)
+			.Process(this->_randomTargetOffset)
+			.Process(this->_facingRad)
+			.Process(this->_currentAngle)
+			.Process(this->_prevCirclePos)
+			.Process(this->_currentCircleRadius)
+			.Process(this->_currentCircleSpeed)
+			.Process(this->_currentCircleAngle);
 		return stream.Success();
 	};
 
@@ -61,13 +93,24 @@ public:
 	}
 #pragma endregion
 
-	CoordStruct _initialLocation{};
-	CoordStruct _initialTarget{};
-	CoordStruct _initialOriginPos{};
-	CoordStruct _randomTargetOffset{};
+	bool _active = false;
+	int _elapsedFrames = 0;             // 已执行运动帧数
+	int _moveFrame = 0;                 // 真实帧计数
+	double _currentSpeed = 0.0;         // 当前速度
+	int _effectiveTimeStep = 1;         // 有效 TimeStep
+
+	CoordStruct _initialLocation{};     // 初始位置快照
+	CoordStruct _initialOriginPos{};    // 初始 Origin 快照（NoUpdate 用）
 	ObjectClass* _pLauncher = nullptr;
+	ObjectClass* _pTarget = nullptr;
 	ObjectClass* _pSource = nullptr;
-	int _currentSpeed = 0;
-	int _elapsedFrames = 0;
-	int _moveFrame = 0;
+
+	int _totalDuration = 0;             // AE 总持续时间（ReachTarget 用）
+	CoordStruct _randomTargetOffset{};  // 随机偏移
+	double _facingRad = 0.0;           // OnStart 时锁定的朝向弧度（FLH 旋转用）
+	double _currentAngle = 0.0;        // MoveTo 模式自增角度（°）
+	CoordStruct _prevCirclePos{};      // MoveTo 圆周模式上一帧世界坐标
+	double _currentCircleRadius = 0.0; // Circle 模式动态半径
+	double _currentCircleSpeed = 0.0;  // Circle 模式动态线速度
+	double _currentCircleAngle = 0.0;  // Circle 模式动态角速度
 };

--- a/src/Ext/ObjectType/AttachEffect.cpp
+++ b/src/Ext/ObjectType/AttachEffect.cpp
@@ -1,4 +1,4 @@
-﻿#include "AttachEffect.h"
+#include "AttachEffect.h"
 
 #include <BuildingClass.h>
 #include <MissionClass.h>
@@ -240,18 +240,23 @@ VectorResult AttachEffect::MarginVectorOffset()
 	CoordStruct currentPos = pObject->GetCoords();
 	ForeachChild([&result, &currentPos](Component* c) {
 		auto temp = dynamic_cast<AttachEffectScript*>(c);
-		if (temp && temp->IsAlive() && !temp->IsPaused() && temp->AEData.Vector.Enable && !temp->AEData.Vector.Freeze)
+		if (temp && temp->IsAlive() && !temp->IsPaused())
 		{
-			if (auto* ve = temp->GetComponent<VectorEffect>())
+			// Vector（替代 V1，包括 Freeze）
+			if (temp->AEData.Vector.Enable)
 			{
-				VectorResult tempResult = ve->GetVectorResult();
-				result.MoveDisp.X += tempResult.MoveDisp.X;
-				result.MoveDisp.Y += tempResult.MoveDisp.Y;
-				result.MoveDisp.Z += tempResult.MoveDisp.Z;
-				result.Freeze |= tempResult.Freeze;
-				if (tempResult.Freeze && !tempResult.FrozenPos.IsEmpty())
+				if (auto* ve = temp->GetComponent<VectorEffect>())
 				{
-					result.FrozenPos = tempResult.FrozenPos;
+					VectorResult tempResult = ve->GetVectorResult();
+					result.MoveDisp.X += tempResult.MoveDisp.X;
+					result.MoveDisp.Y += tempResult.MoveDisp.Y;
+					result.MoveDisp.Z += tempResult.MoveDisp.Z;
+					result.Freeze |= tempResult.Freeze;
+					result.Force |= tempResult.Force;
+					if (tempResult.Freeze && !tempResult.FrozenPos.IsEmpty())
+					{
+						result.FrozenPos = tempResult.FrozenPos;
+					}
 				}
 			}
 		}

--- a/src/Ext/ObjectType/AttachEffect.cpp
+++ b/src/Ext/ObjectType/AttachEffect.cpp
@@ -19,6 +19,8 @@
 #include <Ext/EffectType/Effect/CounterEffect.h>
 #include <Ext/EffectType/Effect/StandEffect.h>
 #include <Ext/EffectType/Effect/VectorEffect.h>
+#include <Ext/EffectType/Effect/TurretSpinEffect.h>
+#include <Ext/EffectType/Effect/BodySpinEffect.h>
 #include <Ext/BulletType/BulletStatus.h>
 #include <Ext/TechnoType/TechnoStatus.h>
 #include <Ext/TechnoType/UploadAttachData.h>
@@ -253,6 +255,9 @@ VectorResult AttachEffect::MarginVectorOffset()
 					result.MoveDisp.Z += tempResult.MoveDisp.Z;
 					result.Freeze |= tempResult.Freeze;
 					result.Force |= tempResult.Force;
+					result.AllowFallingDestroy |= tempResult.AllowFallingDestroy;
+					if (tempResult.FallingDestroyHeight > result.FallingDestroyHeight)
+						result.FallingDestroyHeight = tempResult.FallingDestroyHeight;
 					if (tempResult.Freeze && !tempResult.FrozenPos.IsEmpty())
 					{
 						result.FrozenPos = tempResult.FrozenPos;

--- a/src/Ext/ObjectType/AttachEffect.h
+++ b/src/Ext/ObjectType/AttachEffect.h
@@ -34,6 +34,7 @@ struct VectorResult
 	bool CanPassBuilding = false; // 是否可以穿过建筑
 	bool Freeze = false; // 是否冻结标志位，如果为true，则表示被冻结，位移无效
 	CoordStruct FrozenPos = CoordStruct::Empty; // 冻结时的位置，仅当Freeze为true时有效
+	bool Force = false; // Force 模式，Vector 完全接管位置（非运动帧也 SetLocation 保持原地）
 	bool AllowFallingDestroy = false; // 是否允许掉落摧毁
 	int FallingDestroyHeight = 2 * Unsorted::LevelHeight; // 掉落摧毁高度，仅当AllowFallingDestroy为true时有效
 	bool AllowCrawl = false; // 是否播放爬行帧

--- a/src/Ext/TechnoType/Status/BodySpin.cpp
+++ b/src/Ext/TechnoType/Status/BodySpin.cpp
@@ -1,0 +1,58 @@
+#include "../TechnoStatus.h"
+
+#include <Ext/Helper/Scripts.h>
+#include <Ext/EffectType/Effect/BodySpinData.h>
+
+void TechnoStatus::OnUpdate_BodySpin()
+{
+	if (!pTechno || IsDeadOrInvisible(pTechno))
+		return;
+
+	AttachEffect* aem = AEManager();
+	if (!aem)
+		return;
+
+	BodySpinData* pData = nullptr;
+	aem->ForeachChild([&pData](Component* c) {
+		auto ae = dynamic_cast<AttachEffectScript*>(c);
+		if (ae && ae->IsAlive() && !ae->IsPaused() && ae->AEData.BodySpin.Enable)
+		{
+			pData = &ae->AEData.BodySpin;
+		}
+	});
+	if (!pData)
+		return;
+
+	int speed = pData->Speed;
+	int period = pData->SweepPeriod;
+
+	DirStruct dir = pTechno->PrimaryFacing.Current();
+	double rad = dir.GetValue();
+
+	if (period <= 0)
+	{
+		rad += speed;
+		while (rad >= 32768) rad -= 65536;
+		while (rad < -32768) rad += 65536;
+	}
+	else
+	{
+		rad += _spinTime * speed;
+		while (rad >= 32768) rad -= 65536;
+		while (rad < -32768) rad += 65536;
+
+		if (_spinFlip)
+		{
+			if (++_spinTime >= period)
+				_spinFlip = false;
+		}
+		else
+		{
+			if (--_spinTime <= -period)
+				_spinFlip = true;
+		}
+	}
+
+	dir.SetValue(static_cast<short>(rad));
+	pTechno->PrimaryFacing.SetCurrent(dir);
+}

--- a/src/Ext/TechnoType/Status/TurretSpin.cpp
+++ b/src/Ext/TechnoType/Status/TurretSpin.cpp
@@ -1,0 +1,58 @@
+#include "../TechnoStatus.h"
+
+#include <Ext/Helper/Scripts.h>
+#include <Ext/EffectType/Effect/TurretSpinData.h>
+
+void TechnoStatus::OnUpdate_TurretSpin()
+{
+	if (!pTechno || IsDeadOrInvisible(pTechno))
+		return;
+
+	AttachEffect* aem = AEManager();
+	if (!aem)
+		return;
+
+	TurretSpinData* pData = nullptr;
+	aem->ForeachChild([&pData](Component* c) {
+		auto ae = dynamic_cast<AttachEffectScript*>(c);
+		if (ae && ae->IsAlive() && !ae->IsPaused() && ae->AEData.TurretSpin.Enable)
+		{
+			pData = &ae->AEData.TurretSpin;
+		}
+	});
+	if (!pData)
+		return;
+
+	int speed = pData->Speed;
+	int period = pData->SweepPeriod;
+
+	DirStruct dir = pTechno->SecondaryFacing.Current();
+	double rad = dir.GetValue();
+
+	if (period <= 0)
+	{
+		rad += speed;
+		while (rad >= 32768) rad -= 65536;
+		while (rad < -32768) rad += 65536;
+	}
+	else
+	{
+		rad += _turretTime * speed;
+		while (rad >= 32768) rad -= 65536;
+		while (rad < -32768) rad += 65536;
+
+		if (_turretFlip)
+		{
+			if (++_turretTime >= period)
+				_turretFlip = false;
+		}
+		else
+		{
+			if (--_turretTime <= -period)
+				_turretFlip = true;
+		}
+	}
+
+	dir.SetValue(static_cast<short>(rad));
+	pTechno->SecondaryFacing.SetCurrent(dir);
+}

--- a/src/Ext/TechnoType/Status/Vector.cpp
+++ b/src/Ext/TechnoType/Status/Vector.cpp
@@ -9,7 +9,7 @@
 
 void TechnoStatus::VectorCancel()
 {
-	if (VectorForced && !IsBuilding() && !IsDeadOrInvisible(pTechno))
+	if (!IsBuilding() && !IsDeadOrInvisible(pTechno))
 	{
 		FootClass* pFoot = abstract_cast<FootClass*, true>(pTechno);
 		pFoot->Locomotor->Unlock();
@@ -18,13 +18,18 @@ void TechnoStatus::VectorCancel()
 		{
 			pFoot->ForceMission(Mission::Guard);
 		}
-		// 摔死
-		int fallingDestroyHeight = _vectorResult.AllowFallingDestroy ? _vectorResult.FallingDestroyHeight : 0;
+		// 坠落：取当前高度对地差值或 AllowFallingDestroy 指定高度
+		CellClass* pCell = MapClass::Instance->TryGetCellAt(pTechno->GetCoords());
+		int heightAboveGround = pCell ? (pTechno->GetCoords().Z - pCell->GetCoordsWithBridge().Z) : 0;
+		int fallingDestroyHeight = _vectorResult.AllowFallingDestroy
+			? _vectorResult.FallingDestroyHeight
+			: heightAboveGround;
 		FallingExceptAircraft(pTechno, fallingDestroyHeight, false);
 	}
 	VectorForced = false;
 	_vectorResult = {};
 }
+
 
 void TechnoStatus::OnUpdate_Vector()
 {
@@ -34,11 +39,13 @@ void TechnoStatus::OnUpdate_Vector()
 	bool wasVectorForced = VectorForced;
 
 	_vectorResult = AEManager()->MarginVectorOffset();
-	VectorForced = !_vectorResult.MoveDisp.IsEmpty();
 
-	if (VectorForced)
+	if (!_vectorResult.MoveDisp.IsEmpty())
 	{
+		VectorForced = true;
+		VectorPendingFall = false;
 		CoordStruct location = pTechno->GetCoords();
+
 		if (IsDeadOrInvisible(pTechno))
 		{
 			VectorCancel();
@@ -109,7 +116,6 @@ void TechnoStatus::OnUpdate_Vector()
 						pTechno->PrimaryFacing.SetDesired(facingDir);
 						if (IsJumpjet())
 						{
-							// JJ朝向是单独的Facing
 							if (JumpjetLocomotionClass* jjLoco = dynamic_cast<JumpjetLocomotionClass*>(pFoot->Locomotor.get()))
 							{
 								jjLoco->LocomotionFacing.SetDesired(facingDir);
@@ -117,19 +123,23 @@ void TechnoStatus::OnUpdate_Vector()
 						}
 						else if (IsAircraft())
 						{
-							// 飞机使用的炮塔的Facing
 							pTechno->SecondaryFacing.SetDesired(facingDir);
 						}
 					}
 				}
 			}
-			
 		}
 	}
 	else if (wasVectorForced)
 	{
-		// 从 Force 变为 Unforced，说明 Vector 效果结束了，执行取消逻辑
+		// 延后 1 帧判定坠落，等待 Next= 链条衔接
+		VectorPendingFall = true;
+		VectorForced = false;
+	}
+	else if (VectorPendingFall)
+	{
 		VectorCancel();
+		VectorPendingFall = false;
 	}
 }
 

--- a/src/Ext/TechnoType/TechnoStatus.cpp
+++ b/src/Ext/TechnoType/TechnoStatus.cpp
@@ -198,12 +198,14 @@ void TechnoStatus::OnUpdate()
 		OnUpdate_BalloonTransporter();
 		OnUpdate_BlackHole();
 		OnUpdate_Vector();
+		OnUpdate_BodySpin();
 		OnUpdate_Deselect();
 		OnUpdate_Freeze();
 		OnUpdate_Paintball();
 		OnUpdate_Passenger();
 		OnUpdate_TargetLaser();
 		OnUpdate_GiftBox(); // 礼盒会删除对象，所以放最后
+		OnUpdate_TurretSpin(); // 炮塔旋转最后执行，避免引擎瞄准覆盖
 	}
 }
 

--- a/src/Ext/TechnoType/TechnoStatus.h
+++ b/src/Ext/TechnoType/TechnoStatus.h
@@ -416,6 +416,13 @@ public:
 
 	bool CaptureByBlackHole = false;
 	bool VectorForced = false;
+	bool VectorPendingFall = false;
+	double _spinRad = 0;
+	int _spinTime = 0;
+	bool _spinFlip = true;
+	double _turretRad = 0;
+	int _turretTime = 0;
+	bool _turretFlip = true;
 	bool Jumping = false;
 
 	// 冻结
@@ -497,6 +504,13 @@ public:
 
 			// 向量位移
 			.Process(this->VectorForced)
+			.Process(this->VectorPendingFall)
+			.Process(this->_spinRad)
+			.Process(this->_spinTime)
+			.Process(this->_spinFlip)
+			.Process(this->_turretRad)
+			.Process(this->_turretTime)
+			.Process(this->_turretFlip)
 			.Process(this->_vectorResult)
 			.Success();
 	};
@@ -574,6 +588,8 @@ private:
 	void OnUpdate_TargetLaser();
 	void OnUpdate_Transform();
 	void OnUpdate_Vector();
+	void OnUpdate_TurretSpin();
+	void OnUpdate_BodySpin();
 
 	void OnWarpUpdate_DestroySelf_Stand();
 

--- a/src/Ext/TechnoType/TurretSpin.h
+++ b/src/Ext/TechnoType/TurretSpin.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Common/Components/ScriptComponent.h>
+
+/// 炮塔旋转：暴力覆盖 SecondaryFacing，数据来自 AE
+class TurretSpin : public TechnoScript
+{
+public:
+	TECHNO_SCRIPT(TurretSpin);
+
+	virtual void Clean() override
+	{
+		TechnoScript::Clean();
+		_turretTime = 0;
+		_turretFlip = true;
+	}
+
+	virtual void OnUpdate() override;
+	virtual void OnPut(CoordStruct* pCoord, DirType dirType) override;
+
+private:
+	int _turretTime = 0;
+	bool _turretFlip = true;
+};
+


### PR DESCRIPTION
旋转相关：
BodySpin.Speed
BodySpin.SweepPeriod
TurretSpin.Speed
TurretSpin.SweepPeriod

Vector: 见说明书

Broadcast+AutoWeapon：
单位A发射的抛射体B携带广播，单位C接收。
在广播被C接收到的瞬间，
AutoWeapon.IsAttackerMark=yes，则取B的坐标和C的坐标
ReceiverAttack=yes, C发射武器攻击B的坐标
ReceiverAttack=no，A发射后，抛射体立刻被暴力挪移到B坐标，继续朝C飞行
[Vector标签说明书.txt](https://github.com/user-attachments/files/28941394/Vector.txt)
