### PR TITLE
修复ReachTarget与TimeStep>1连用时距离计算错误

### DIFF
--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -30,7 +30,7 @@ void VectorEffect::OnStart()
 	_effectiveTimeStep = Data->TimeStep;
 
 	_initialLocation = pObject->GetCoords();
-	_totalDuration = AE->GetDuration();
+	_totalDuration = AE->GetDuration() / _effectiveTimeStep;
 
 	_randomTargetOffset.X = Random::RandomRanged(Data->TargetOffsetFMin, Data->TargetOffsetFMax);
 	_randomTargetOffset.Y = Random::RandomRanged(Data->TargetOffsetLMin, Data->TargetOffsetLMax);


### PR DESCRIPTION
## 问题

当 Vector.ReachTarget=true 且 Vector.TimeStep>1 时，ReachTarget 模式的剩余距离计算错误。

### 根因

_totalDuration 存储的是 AE 总真实帧数，而 _elapsedFrames 仅每 TimeStep 帧才 +1（运动帧）。两者单位不一致导致 emainingFrames = _totalDuration - _elapsedFrames 严重偏大，物体移动速度过慢，AE 过期时到不了目标点。

同样影响 ArcHeight 抛物线，	 = _elapsedFrames / _totalDuration 最大只到 1/TimeStep，弧线不完整。

## 修复

将 _totalDuration 从真实帧数改为运动帧数，与 _elapsedFrames 同单位：

`diff
- _totalDuration = AE->GetDuration();
+ _totalDuration = AE->GetDuration() / _effectiveTimeStep;
`

## 影响范围

- 仅 TimeStep>1 + ReachTarget=true 时触发，默认配置无影响